### PR TITLE
Added custom texture banners

### DIFF
--- a/Source/Elements/Sprite.cs
+++ b/Source/Elements/Sprite.cs
@@ -90,34 +90,20 @@ namespace RAGENativeUI.Elements
         /// <summary>
         /// Draw a custom texture from a file on a 1080-pixels height base.
         /// </summary>
-        /// <param name="path">Path to texture file.</param>
+        /// <param name="texture">Your custom texture object.</param>
         /// <param name="position"></param>
         /// <param name="size"></param>
-        //public static void DrawTexture(string path, Point position, Size size)
-        //{
-        //    /*
-        //    int screenw = Game.Resolution.Width;
-        //    int screenh = Game.Resolution.Height;
+        public static void DrawTexture(Texture texture, Point position, Size size, GraphicsEventArgs canvas)
+        { 
+            var origRes = Game.Resolution;
+            float aspectRaidou = origRes.Width / (float)origRes.Height;
             
-        //    const float height = 1080f;
-        //    float ratio = (float)screenw / screenh;
-        //    float width = height * ratio;
-            
-        //    float reduceX = 1280 / width;
-        //    float reduceY = 720 / height;
+            PointF pos = new PointF(position.X / (1080 * aspectRaidou), position.Y / 1080f);
+            SizeF siz = new SizeF(size.Width / (1080 * aspectRaidou), size.Height / 1080f);
 
-            
-        //    Point extra = new Point(0,0);
-        //    if (screenw == 1914 && screenh == 1052) //TODO: Fix this when ScriptHookVDotNet 1.2 comes out.
-        //        extra = new Point(15, 0);
-            
-        //    //UI.DrawTexture(path, 1, 1, 60,
-        //    //    new Point(Convert.ToInt32(position.X*reduceX) + extra.X, Convert.ToInt32(position.Y*reduceY) + extra.Y),
-        //    //    new PointF(0f, 0f), 
-        //    //    new Size(Convert.ToInt32(size.Width * reduceX), Convert.ToInt32(size.Height * reduceY)),
-        //    //    0f, Color.White);
-        //    */
-        //}
+            canvas.Graphics.DrawTexture(texture, pos.X* Game.Resolution.Width, pos.Y* Game.Resolution.Height, siz.Width* Game.Resolution.Width, siz.Height* Game.Resolution.Height);
+
+        }
 
         
         /// <summary>

--- a/Source/MenuPool.cs
+++ b/Source/MenuPool.cs
@@ -127,6 +127,16 @@ namespace RAGENativeUI
 
 
         /// <summary>
+        /// Draw all of your menus' custom banners.
+        /// </summary>
+        /// <param name="canvas">Canvas to draw on.</param>
+        public void DrawBanners(GraphicsEventArgs canvas)
+        {
+            _menuList.ForEach(menu => menu.DrawBanner(canvas));
+        }
+
+
+        /// <summary>
         /// Closes all of your menus.
         /// </summary>
         public void CloseAllMenus()
@@ -147,10 +157,10 @@ namespace RAGENativeUI
             _menuList.ForEach(m => m.SetBannerType(bannerType));
         }
 
-        //public void SetBannerType(string bannerPath)
-        //{
-        //    _menuList.ForEach(m => m.SetBannerType(bannerPath));
-        //}
+        public void SetBannerType(Texture banner)
+        {
+            _menuList.ForEach(m => m.SetBannerType(banner));
+        }
 
         public void SetKey(Common.MenuControls menuControl, GameControl control)
         {

--- a/Source/UIMenu.cs
+++ b/Source/UIMenu.cs
@@ -152,7 +152,7 @@ namespace RAGENativeUI
         /// <param name="title">Title that appears on the big banner. Set to "" if you don't want a title.</param>
         /// <param name="subtitle">Subtitle that appears in capital letters in a small black bar. Set to "" if you dont want a subtitle.</param>
         /// <param name="offset">Point object with X and Y data for offsets. Applied to all menu elements.</param>
-        /// <param name="customBanner">Path to your custom texture.</param>
+        /// <param name="customBanner">Your custom Rage.Texture.</param>
         public UIMenu(string title, string subtitle, Point offset, Texture customBanner) : this(title, subtitle, offset, "commonmenu", "interaction_bgd")
         {
             _customBanner = customBanner;

--- a/Source/UIMenu.cs
+++ b/Source/UIMenu.cs
@@ -52,7 +52,7 @@ namespace RAGENativeUI
         private readonly ResText _descriptionText;
         private readonly ResText _counterText;
 
-        private string _customBanner;
+        private Texture _customBanner;
 
         private int _activeItem = 1000;
 
@@ -153,10 +153,10 @@ namespace RAGENativeUI
         /// <param name="subtitle">Subtitle that appears in capital letters in a small black bar. Set to "" if you dont want a subtitle.</param>
         /// <param name="offset">Point object with X and Y data for offsets. Applied to all menu elements.</param>
         /// <param name="customBanner">Path to your custom texture.</param>
-        //public UIMenu(string title, string subtitle, Point offset, string customBanner) : this(title, subtitle, offset, "commonmenu", "interaction_bgd")
-        //{
-        //    _customBanner = customBanner;
-        //}
+        public UIMenu(string title, string subtitle, Point offset, Texture customBanner) : this(title, subtitle, offset, "commonmenu", "interaction_bgd")
+        {
+            _customBanner = customBanner;
+        }
 
         /// <summary>
         /// Advanced Menu constructor that allows custom title banner.
@@ -364,14 +364,14 @@ namespace RAGENativeUI
             _tmpRectangle.Size = new Size(431 + WidthOffset, 107);
         }
 
-        ///// <summary>         /* ADD CUSTOM BANNERS */
-        ///// Set the banner to your own custom texture. Set it to "" if you want to restore the banner.[not implemented]
-        ///// </summary>
-        ///// <param name="pathToCustomSprite">Path to your sprite image.</param>
-        //public void SetBannerType(string pathToCustomSprite)
-        //{
-        //    _customBanner = pathToCustomSprite;
-        //}
+        /// <summary>
+        /// Set the banner to your own custom texture. Set it to null if you want to restore the banner.
+        /// </summary>
+        /// <param name="texture">Rage.Texture object</param>
+        public void SetBannerType(Texture texture)
+        {
+            _customBanner = texture;
+        }
 
         /// <summary>
         /// Add an item to the menu.
@@ -428,6 +428,29 @@ namespace RAGENativeUI
             MenuItems.Clear();
             RecaulculateDescriptionPosition();
         }
+
+
+        /// <summary>
+        /// Draw your custom banner.
+        /// </summary>
+        /// <param name="e">Rage.GraphicsEventArgs to draw on.</param>
+        public void DrawBanner(GraphicsEventArgs e)
+        {
+            if(!Visible || _customBanner == null) return;
+            var origRes = Game.Resolution;
+            var safe = GetSafezoneBounds();
+            float aspectRaidou = origRes.Width / (float)origRes.Height;
+
+            Point bannerPos = new Point(_offset.X + safe.X, _offset.Y + safe.Y);
+            Size bannerSize = new Size(431 + WidthOffset, 107);
+
+            PointF pos = new PointF(bannerPos.X / (1080 * aspectRaidou), bannerPos.Y / 1080f);
+            SizeF siz = new SizeF(bannerSize.Width / (1080 * aspectRaidou), bannerSize.Height / 1080f);
+
+            //Bug: funky positionment on windowed games + max resolution.
+
+            e.Graphics.DrawTexture(_customBanner, pos.X*Game.Resolution.Width, pos.Y*Game.Resolution.Height, siz.Width*Game.Resolution.Width, siz.Height*Game.Resolution.Height);
+        }
         
         /// <summary>
         /// Draw the menu and all of it's components.
@@ -446,7 +469,7 @@ namespace RAGENativeUI
             NativeFunction.CallByHash<uint>(0xf5a2c681787e579d, 0f, 0f, 0f, 0f);   // stuff
 
 
-            if (String.IsNullOrWhiteSpace(_customBanner))
+            if (_customBanner == null)
             {
                 if (_logo != null)
                     _logo.Draw();
@@ -454,11 +477,6 @@ namespace RAGENativeUI
                 {
                     _tmpRectangle.Draw();
                 }
-            }
-            else
-            {
-                Point safe = GetSafezoneBounds();
-                //Sprite.DrawTexture(_customBanner, new Point(safe.X + _offset.X, safe.Y + _offset.Y), new Size(431 + WidthOffset, 107));
             }
             _mainMenu.Draw();
             if (MenuItems.Count == 0)


### PR DESCRIPTION
Seems to work as intended, except when you are using Windowed and have it set to the maximum resolution, where the banner slides a bit to the left.
Also a little bit of flickering, but there's nothing I can do about it I think.

Usage:
```
var myMenu = new UIMenu("", "TEST");
myMenu.SetBannerType(Game.CreateTextureFromFile("banner.png"));
menuPool.Add(myMenu);

public static void FrameRender(object sender, GraphicsEventArgs e)
{
    menuPool.ProcessMenus();
    menuPool.DrawBanners(e);
}
```