### PR TITLE
Fixed compatibility with RPH 0.39 changes to KeyboardState

### DIFF
--- a/Source/Common.cs
+++ b/Source/Common.cs
@@ -2,6 +2,7 @@ using System.Windows.Forms;
 using Rage;
 using Rage.Native;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace RAGENativeUI
 {
@@ -70,7 +71,7 @@ namespace RAGENativeUI
 
         public static IList<Keys> GetPressedKeys()
         {
-            return Game.GetKeyboardState().PressedKeys;
+            return Game.GetKeyboardState().PressedKeys.ToList();
         }
     }
 }


### PR DESCRIPTION
Simply added .ToList() using LINQ to convert from ICollection<Keys> to IList<Keys>. 

I had to change a couple of other things in the solution properties to get it to compile on my machine, but I think that's a development environment thing, so I only committed the relevant code changes. I also didn't change the version number as I'm not sure how you do versioning. 