### PR TITLE
Re-add ProcessControls() call to TabView

### DIFF
--- a/Source/PauseMenu/TabView.cs
+++ b/Source/PauseMenu/TabView.cs
@@ -216,6 +216,8 @@ namespace RAGENativeUI.PauseMenu
             NativeFunction.CallByName<uint>("HIDE_HUD_AND_RADAR_THIS_FRAME");
             //NativeFunction.CallByHash<uint>(0xaae7ce1d63167423); // _SHOW_CURSOR_THIS_FRAME
             
+            ProcessControls();
+            
             var res = UIMenu.GetScreenResolutionMantainRatio();
             var safe = new Point(300, 180);
 


### PR DESCRIPTION
Since 1.6, `TabView`s were not taking any action on indicated keybind presses. It would appear that a call to `ProcessControls()` was removed.

Re-adding this call to the `Update()` method for `TabView` resolves the issue.