### PR TITLE
Use NativeFunction.Natives to call ENABLE_CONTROL_ACTION etc.

### DIFF
--- a/Source/UIMenu.cs
+++ b/Source/UIMenu.cs
@@ -278,12 +278,16 @@ namespace RAGENativeUI
         /// <param name="enable"></param>
         public static void DisEnableControls(bool enable)
         {
-            string thehash = enable ? "ENABLE_CONTROL_ACTION" : "DISABLE_CONTROL_ACTION";
             foreach (var con in Enum.GetValues(typeof(GameControl)))
             {
-                NativeFunction.CallByName<uint>(thehash, 0, (int)con);
-                NativeFunction.CallByName<uint>(thehash, 1, (int)con);
-                NativeFunction.CallByName<uint>(thehash, 2, (int)con);
+                if (enable)
+                {
+                    NativeFunction.Natives.ENABLE_CONTROL_ACTION(0, (int)con);
+                }
+                else
+                {
+                    NativeFunction.Natives.DISABLE_CONTROL_ACTION(0, (int)con);
+                }
             }
             //Controls we want
             // -Frontend
@@ -336,7 +340,7 @@ namespace RAGENativeUI
 
             foreach (var control in list)
             {
-                NativeFunction.CallByName<uint>("ENABLE_CONTROL_ACTION", 0, (int)control);
+                NativeFunction.Natives.ENABLE_CONTROL_ACTION(0, (int)control);
             }
         }
                


### PR DESCRIPTION
As of RagePluginHook 0.60, (possibly 58/59 as well), calling natives using `NativeFunction.CallByName<return_type>` appears to be 3-4 times slower than calling them using the new calling convention ` NativeFunction.Natives.NATIVE_NAME<return_type>`.

This manifests itself in poor framerate whenever a RNUI menu is open. My analysis suggests that the time is lost here in `DisEnableControls()` during its calls to `ENABLE_CONTROL_ACTION` and `DISABLE_CONTROL_ACTION`.

In my testing, refactoring this method to use the new calling convention improves the framerate significantly. (Presumably, there are other places where RNUI calls natives that may also be affected).