### PR TITLE
(#56) Make number of items to display changeable on a per-UIMenu basis

### DIFF
--- a/Source/Common.cs
+++ b/Source/Common.cs
@@ -117,5 +117,18 @@ namespace RAGENativeUI
             }
             return Path.GetFullPath(savePath);
         }
+
+
+        /// <param name="min">Maximum value, inclusive</param>
+        /// <param name="max">Maximum value, exclusive</param>
+        internal static int Wrap(int value, int min, int max)
+        {
+            if (value < min)
+                value = (max - (min - value) % (max - min)) % max;
+            else
+                value = min + (value - min) % (max - min);
+
+            return value;
+        }
     }
 }

--- a/Source/UIMenu.cs
+++ b/Source/UIMenu.cs
@@ -60,18 +60,17 @@ namespace RAGENativeUI
 
         private Texture _customBanner;
 
-        private int _activeItem = 1000;
+        private int currentItem;
+        private int minItem;
+        private int maxItem;
         private int hoveredItem = -1;
-        private bool _visible;
+        private const int MaxItemsOnScreen = 10;
 
+        private bool _visible;
         private bool _justOpened = true;
 
         private int hoveredUpDown = 0; // 0 = none, 1 = up, 2 = down
 
-        //Pagination
-        private const int MaxItemsOnScreen = 9; // TODO: one more item than specified in MaxItemsOnScreen is drawn
-        private int _minItem;
-        private int _maxItem = MaxItemsOnScreen;
 
         private readonly InstructionalButtons instructionalButtons;
         private bool instructionalButtonsEnabled = true;
@@ -189,6 +188,8 @@ namespace RAGENativeUI
             {
                 CounterPretext = subtitle.Substring(0, subtitle.IndexOf('~', 1) + 1);
             }
+
+            CurrentSelection = -1;
 
             SetKey(Common.MenuControls.Up, GameControl.CellphoneUp);
             SetKey(Common.MenuControls.Up, GameControl.CursorScrollUp);
@@ -371,12 +372,13 @@ namespace RAGENativeUI
         /// <param name="index">Index to remove the item at.</param>
         public void RemoveItemAt(int index)
         {
-            if (MenuItems.Count > MaxItemsOnScreen && _maxItem == MenuItems.Count - 1)
+            if (maxItem == MenuItems.Count - 1) // if max visible item matches last item, move the visible item range up by one item
             {
-                _maxItem--;
-                _minItem--;
+                minItem = Math.Max(minItem - 1, 0);
+                maxItem = Math.Max(maxItem - 1, 0);
             }
             MenuItems.RemoveAt(index);
+            CurrentSelection = CurrentSelection; // refresh the current selection in case we removed the selected item
         }
 
         /// <summary>
@@ -386,18 +388,14 @@ namespace RAGENativeUI
         {
             if (MenuItems.Count == 0)
             {
-                _activeItem = 1000;
-                _maxItem = MaxItemsOnScreen;
-                _minItem = 0;
+                CurrentSelection = -1;
                 return;
             }
 
             for (int i = 0; i < MenuItems.Count; i++)
                 MenuItems[i].Selected = false;
 
-            _activeItem = 1000 - (1000 % MenuItems.Count);
-            _maxItem = MaxItemsOnScreen;
-            _minItem = 0;
+            CurrentSelection = 0;
         }
 
         /// <summary>
@@ -538,8 +536,6 @@ namespace RAGENativeUI
 
             DrawBackground(x, headerBottom);
 
-            MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
-
             DrawItems(x, ref y);
 
             DrawUpDownArrows(x, ref y);
@@ -642,7 +638,7 @@ namespace RAGENativeUI
             {
                 counterText = CounterPretext + CounterOverride;
             }
-            else if (MenuItems.Count > MaxItemsOnScreen + 1)
+            else if (MenuItems.Count > MaxItemsOnScreen)
             {
                 counterText = CounterPretext + (CurrentSelection + 1) + " / " + MenuItems.Count;
             }
@@ -677,7 +673,7 @@ namespace RAGENativeUI
         private void DrawBackground(float x, float headerBottom)
         {
             float bgWidth = menuWidth;
-            float bgHeight = itemHeight * (MenuItems.Count > MaxItemsOnScreen + 1 ? MaxItemsOnScreen + 1 : MenuItems.Count);
+            float bgHeight = itemHeight * Math.Min(MenuItems.Count, MaxItemsOnScreen);
 
             DrawSprite(CommonTxd, BackgroundTextureName,
                        x + bgWidth * 0.5f,
@@ -692,28 +688,17 @@ namespace RAGENativeUI
             itemsX = x;
             itemsY = y;
 
-            if (MenuItems.Count <= MaxItemsOnScreen + 1)
+            for (int index = minItem; index <= maxItem; index++)
             {
-                foreach (var item in MenuItems)
-                {
-                    item.Draw(x, y, menuWidth, itemHeight);
-                    y += itemHeight;
-                }
-            }
-            else
-            {
-                for (int index = _minItem; index <= _maxItem; index++)
-                {
-                    var item = MenuItems[index];
-                    item.Draw(x, y, menuWidth, itemHeight);
-                    y += itemHeight;
-                }
+                var item = MenuItems[index];
+                item.Draw(x, y, menuWidth, itemHeight);
+                y += itemHeight;
             }
         }
 
         private void DrawUpDownArrows(float x, ref float y)
         {
-            if (MenuItems.Count > MaxItemsOnScreen + 1)
+            if (MenuItems.Count > MaxItemsOnScreen)
             {
                 float upDownRectWidth = menuWidth;
                 float upDownRectHeight = itemHeight;
@@ -751,7 +736,7 @@ namespace RAGENativeUI
                 return;
             }
 
-            string description = MenuItems[_activeItem % (MenuItems.Count)].Description;
+            string description = MenuItems[CurrentSelection].Description;
             if (!String.IsNullOrWhiteSpace(description))
             {
                 y += 0.00277776f * 2f;
@@ -969,37 +954,10 @@ namespace RAGENativeUI
         /// <summary>
         /// Go up the menu if the number of items is more than maximum items on screen.
         /// </summary>
+        [Obsolete("Use UIMenu.GoUp() instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public void GoUpOverflow()
         {
-            if (MenuItems.Count <= MaxItemsOnScreen + 1) return;
-            if (_activeItem % MenuItems.Count <= _minItem)
-            {
-                if (_activeItem % MenuItems.Count == 0)
-                {
-                    _minItem = MenuItems.Count - MaxItemsOnScreen - 1;
-                    _maxItem = MenuItems.Count - 1;
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-                    _activeItem = 1000 - (1000 % MenuItems.Count);
-                    _activeItem += MenuItems.Count - 1;
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
-                }
-                else
-                {
-                    _minItem--;
-                    _maxItem--;
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-                    _activeItem--;
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
-                }
-            }
-            else
-            {
-                MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-                _activeItem--;
-                MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
-            }
-            Common.PlaySound(AUDIO_UPDOWN, AUDIO_LIBRARY);
-            IndexChange(CurrentSelection);
+            GoUp();
         }
 
         /// <summary>
@@ -1007,10 +965,8 @@ namespace RAGENativeUI
         /// </summary>
         public void GoUp()
         {
-            if (MenuItems.Count > MaxItemsOnScreen + 1) return;
-            MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-            _activeItem--;
-            MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
+            CurrentSelection--;
+
             Common.PlaySound(AUDIO_UPDOWN, AUDIO_LIBRARY);
             IndexChange(CurrentSelection);
         }
@@ -1018,36 +974,10 @@ namespace RAGENativeUI
         /// <summary>
         /// Go down the menu if the number of items is more than maximum items on screen.
         /// </summary>
+        [Obsolete("Use UIMenu.GoDown() instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public void GoDownOverflow()
         {
-            if (MenuItems.Count <= MaxItemsOnScreen + 1) return;
-            if (_activeItem % MenuItems.Count >= _maxItem)
-            {
-                if (_activeItem % MenuItems.Count == MenuItems.Count - 1)
-                {
-                    _minItem = 0;
-                    _maxItem = MaxItemsOnScreen;
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-                    _activeItem = 1000 - (1000 % MenuItems.Count);
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
-                }
-                else
-                {
-                    _minItem++;
-                    _maxItem++;
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-                    _activeItem++;
-                    MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
-                }
-            }
-            else
-            {
-                MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-                _activeItem++;
-                MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
-            }
-            Common.PlaySound(AUDIO_UPDOWN, AUDIO_LIBRARY);
-            IndexChange(CurrentSelection);
+            GoDown();
         }
 
         /// <summary>
@@ -1055,10 +985,8 @@ namespace RAGENativeUI
         /// </summary>
         public void GoDown()
         {
-            if (MenuItems.Count > MaxItemsOnScreen + 1) return;
-            MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-            _activeItem++;
-            MenuItems[_activeItem % (MenuItems.Count)].Selected = true;
+            CurrentSelection++;
+
             Common.PlaySound(AUDIO_UPDOWN, AUDIO_LIBRARY);
             IndexChange(CurrentSelection);
         }
@@ -1222,17 +1150,11 @@ namespace RAGENativeUI
             {
                 if (hoveredUpDown == 1)
                 {
-                    if (MenuItems.Count > MaxItemsOnScreen + 1)
-                        GoUpOverflow();
-                    else
-                        GoUp();
+                    GoUp();
                 }
                 else
                 {
-                    if (MenuItems.Count > MaxItemsOnScreen + 1)
-                        GoDownOverflow();
-                    else
-                        GoDown();
+                    GoDown();
                 }
                 instructionalButtons.Update();
             }
@@ -1314,7 +1236,7 @@ namespace RAGENativeUI
         {
             BeginScriptGfx();
 
-            int visibleItemCount = Math.Min(MenuItems.Count, MaxItemsOnScreen + 1);
+            int visibleItemCount = Math.Min(MenuItems.Count, MaxItemsOnScreen);
             float x1 = itemsX, y1 = itemsY - 0.00138888f; // background top-left
             float x2 = itemsX + menuWidth, y2 = y1 + visibleItemCount * itemHeight; // background bottom-right
             N.GetScriptGfxPosition(x1, y1, out x1, out y1);
@@ -1324,8 +1246,7 @@ namespace RAGENativeUI
 
             if (mouseX >= x1 && mouseX <= x2 && mouseY >= y1 && mouseY <= y2) // hovering items background
             {
-                int firstVisibleItem = Math.Max(0, _minItem);
-                int hoveredIdx = firstVisibleItem + (int)((mouseY - y1) / itemHeight);
+                int hoveredIdx = minItem + (int)((mouseY - y1) / itemHeight);
 
                 if (hoveredItem != hoveredIdx)
                 {
@@ -1348,7 +1269,7 @@ namespace RAGENativeUI
 
         private void UpdateHoveredUpDown(float mouseX, float mouseY)
         {
-            if (MenuItems.Count > MaxItemsOnScreen + 1)
+            if (MenuItems.Count > MaxItemsOnScreen)
             {
                 BeginScriptGfx();
 
@@ -1590,19 +1511,13 @@ namespace RAGENativeUI
             if (MenuItems.Count == 0) return;
             if (IsControlBeingPressed(Common.MenuControls.Up, key))
             {
-                if (MenuItems.Count > MaxItemsOnScreen + 1)
-                    GoUpOverflow();
-                else
-                    GoUp();
+                GoUp();
                 instructionalButtons.Update();
             }
 
             else if (IsControlBeingPressed(Common.MenuControls.Down, key))
             {
-                if (MenuItems.Count > MaxItemsOnScreen + 1)
-                    GoDownOverflow();
-                else
-                    GoDown();
+                GoDown();
                 instructionalButtons.Update();
             }
 
@@ -1707,20 +1622,39 @@ namespace RAGENativeUI
         /// </summary>
         public int CurrentSelection
         {
-            get { return _activeItem % MenuItems.Count; }
+            get { return currentItem; }
             set
             {
-                MenuItems[_activeItem % (MenuItems.Count)].Selected = false;
-                _activeItem = 1000 - (1000 % MenuItems.Count) + value;
-                if (CurrentSelection > _maxItem)
+                if (MenuItems.Count == 0)
                 {
-                    _maxItem = CurrentSelection;
-                    _minItem = CurrentSelection - MaxItemsOnScreen;
+                    currentItem = -1;
+                    minItem = -1;
+                    maxItem = -1;
                 }
-                else if (CurrentSelection < _minItem)
+                else
                 {
-                    _maxItem = MaxItemsOnScreen + CurrentSelection;
-                    _minItem = CurrentSelection;
+                    if (currentItem >= 0 && currentItem < MenuItems.Count)
+                    {
+                        MenuItems[currentItem].Selected = false;
+                    }
+                    currentItem = Common.Wrap(value, 0, MenuItems.Count);
+                    MenuItems[currentItem].Selected = true;
+
+                    if (minItem == -1 || maxItem == -1) // if no previous selection
+                    {
+                        minItem = 0;
+                        maxItem = Math.Min(MenuItems.Count, MaxItemsOnScreen) - 1;
+                    }
+                    else if (currentItem < minItem) // moved selection up, out of current visible item
+                    {
+                        minItem = currentItem;
+                        maxItem = currentItem + Math.Min(MaxItemsOnScreen, MenuItems.Count) - 1;
+                    }
+                    else if (currentItem > maxItem) // moved selection down, out of current visible item
+                    {
+                        minItem = currentItem - Math.Min(MaxItemsOnScreen, MenuItems.Count) + 1;
+                        maxItem = currentItem;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Simplified how `currentItem`, `minItem` and `maxItem` indices are handled.
- Converted `MaxItemsOnScreen` from constant to instance property.
- Added `DefaultMaxItemsOnScreen` constant.

Closes #56.