### PR TITLE
(#52) InstructionalButtons improvements

### DIFF
--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -153,9 +153,12 @@ namespace RAGENativeUI.Elements
         }
 
         public static string GetButtonId(string keyString)
-        {
-            return "t_" + keyString;
-        }
+            => keyString.Length switch
+            {
+                int n when n <= 2 => "t_",
+                int n when n <= 4 => "T_",
+                _ => "w_"
+            } + keyString;
     }
 }
 

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -4,11 +4,15 @@ namespace RAGENativeUI.Elements
     using System.Linq;
     using System.Collections.Generic;
     using Rage;
+    using System.Drawing;
 
     public class InstructionalButtons
     {
+        public static readonly Color DefaultBackgroundColor = Color.FromArgb(80, 0, 0, 0);
+
         public Scaleform Scaleform { get; }
         public InstructionalButtonsCollection Buttons { get; }
+        public Color BackgroundColor { get; set; } = DefaultBackgroundColor;
 
         public InstructionalButtons()
         {
@@ -31,17 +35,17 @@ namespace RAGENativeUI.Elements
         {
             Scaleform.CallFunction("CLEAR_ALL");
             Scaleform.CallFunction("TOGGLE_MOUSE_BUTTONS", 0);
-            Scaleform.CallFunction("CREATE_CONTAINER");
 
-            int dateSlotIndex = 0;
-            for (int i = 0; i < Buttons.Count; i++)
+            for (int i = 0, slot = 0; i < Buttons.Count; i++)
             {
                 IInstructionalButtonSlot b = Buttons[i];
-                if (b.CanBeDisplayed == null || b.CanBeDisplayed.Invoke(b))
+                if (b.CanBeDisplayed == null || b.CanBeDisplayed(b))
                 {
-                    Scaleform.CallFunction("SET_DATA_SLOT", dateSlotIndex++, b.GetButtonId(), b.Text ?? "");
+                    Scaleform.CallFunction("SET_DATA_SLOT", slot++, b.GetButtonId(), b.Text ?? "");
                 }
             }
+
+            Scaleform.CallFunction("SET_BACKGROUND_COLOUR", (int)BackgroundColor.R, (int)BackgroundColor.G, (int)BackgroundColor.B, (int)BackgroundColor.A);
             Scaleform.CallFunction("DRAW_INSTRUCTIONAL_BUTTONS", -1);
         }
 

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -57,7 +57,7 @@ namespace RAGENativeUI.Elements
                 IInstructionalButtonSlot b = Buttons[i];
                 if (b.CanBeDisplayed == null || b.CanBeDisplayed(b))
                 {
-                    Scaleform.CallFunction("SET_DATA_SLOT", slot++, b.GetButtonId(), b.Text ?? "");
+                    Scaleform.CallFunction("SET_DATA_SLOT", slot++, b.GetButtonId() ?? string.Empty, b.Text ?? string.Empty);
                 }
             }
 
@@ -112,6 +112,10 @@ namespace RAGENativeUI.Elements
 
         /// <summary>
         /// Gets or sets the contents of the button.
+        /// <para>
+        /// If this <see cref="InstructionalButton"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
+        /// <see cref="InstructionalButtons.Update"/> needs to be called to reflect the changes made.
+        /// </para>
         /// </summary>
         public InstructionalButtonId Button { get; set; }
 
@@ -168,29 +172,59 @@ namespace RAGENativeUI.Elements
         /// <inheritdoc/>
         public Predicate<IInstructionalButtonSlot> CanBeDisplayed { get; set; }
 
+        /// <summary>
+        /// Gets or sets the list containing the buttons of this group.
+        /// <para>
+        /// If this <see cref="InstructionalButtonGroup"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
+        /// <see cref="InstructionalButtons.Update"/> needs to be called to reflect the changes made.
+        /// </para>
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// <c>value</c> is null.
+        /// </exception>
         public IList<InstructionalButtonId> Buttons
         {
             get => buttons;
             set => buttons = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonGroup"/> class.
+        /// </summary>
+        /// <param name="buttons">The buttons to be displayed.</param>
+        /// <param name="text">The text displayed next to the buttons.</param>
         public InstructionalButtonGroup(IEnumerable<InstructionalButtonId> buttons, string text)
         {
             Text = text;
             Buttons = new List<InstructionalButtonId>(buttons);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonGroup"/> class.
+        /// </summary>
+        /// <param name="controls">The <see cref="GameControl"/>s contained in the group, they change depending on keybinds and whether the user is using the controller or the keyboard and mouse.</param>
+        /// <param name="text">The text displayed next to the buttons.</param>
         public InstructionalButtonGroup(IEnumerable<GameControl> controls, string text) : this(controls.Select(x => (InstructionalButtonId)x), text) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonGroup"/> class.
+        /// </summary>
+        /// <param name="buttonTexts">The text displayed inside the buttons in the group, mainly for displaying custom keyboard bindings, like "I", or "O", or "F5".</param>
+        /// <param name="text">The text displayed next to the buttons.</param>
         public InstructionalButtonGroup(IEnumerable<string> buttonTexts, string text) : this(buttonTexts.Select(x => (InstructionalButtonId)x), text) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonGroup"/> class.
+        /// </summary>
+        /// <param name="rawIds">The raw identifiers of the symbols to be displayed in the group.</param>
+        /// <param name="text">The text displayed next to the buttons.</param>
         public InstructionalButtonGroup(IEnumerable<uint> rawIds, string text) : this(rawIds.Select(x => (InstructionalButtonId)x), text) { }
 
         /// <inheritdoc/>
         public string GetButtonId() => GetButtonId(Buttons);
 
         public static string GetButtonId(IEnumerable<InstructionalButtonId> buttons)
-            => buttons.Reverse().Aggregate("", (acc, btn) => acc + (acc.Length == 0 ? "" : "%") + btn.Id);
+            => buttons.Reverse().Aggregate(string.Empty, (acc, btn) => acc + (acc.Length == 0 ? string.Empty : "%") + btn.Id);
     }
 
     public readonly struct InstructionalButtonId
@@ -206,7 +240,7 @@ namespace RAGENativeUI.Elements
         private readonly string id;
 
         /// <summary>
-        /// Gets the string that represents the button contents.
+        /// Gets the <see cref="string"/> that represents the button contents.
         /// </summary>
         public string Id => id ?? (control.HasValue ? N.GetControlInstructionalButton(2, control.Value)  : EmptyButtonId);
 

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -1,9 +1,9 @@
 namespace RAGENativeUI.Elements
 {
     using System;
-
+    using System.Linq;
+    using System.Collections.Generic;
     using Rage;
-    using Rage.Native;
 
     public class InstructionalButtons
     {
@@ -36,7 +36,7 @@ namespace RAGENativeUI.Elements
             int dateSlotIndex = 0;
             for (int i = 0; i < Buttons.Count; i++)
             {
-                InstructionalButton b = Buttons[i];
+                IInstructionalButtonSlot b = Buttons[i];
                 if (b.CanBeDisplayed == null || b.CanBeDisplayed.Invoke(b))
                 {
                     Scaleform.CallFunction("SET_DATA_SLOT", dateSlotIndex++, b.GetButtonId(), b.Text ?? "");
@@ -46,102 +46,175 @@ namespace RAGENativeUI.Elements
         }
 
 
-        public class InstructionalButtonsCollection : BaseCollection<InstructionalButton>
+        public class InstructionalButtonsCollection : BaseCollection<IInstructionalButtonSlot>
         {
         }
     }
 
-    public class InstructionalButton
+    public interface IInstructionalButtonSlot
     {
         /// <summary>
         /// Gets or sets the text displayed next to the button.
         /// <para>
-        /// If this <see cref="InstructionalButton"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
+        /// If this <see cref="IInstructionalButtonSlot"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
         /// <see cref="InstructionalButtons.Update"/> needs to be called to reflect the changes made.
         /// </para>
         /// </summary>
         /// <value>
-        /// A <see cref="String"/> representing the text displayed next to the button.
+        /// A <see cref="string"/> representing the text displayed next to the button.
         /// </value>
         public string Text { get; set; }
 
         /// <summary>
-        /// Gets or sets the text displayed inside the button, mainly for displaying custom keyboard bindings, like "I", or "O", or "F5".
+        /// Gets or sets the <see cref="Predicate{T}"/> that defines the conditions for this <see cref="IInstructionalButtonSlot"/> to be visible.
         /// <para>
-        /// If <c>null</c>, <see cref="ButtonControl"/> is used instead.
-        /// </para>
-        /// <para>
-        /// If this <see cref="InstructionalButton"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
-        /// <see cref="InstructionalButtons.Update"/> needs to be called to reflect the changes made.
-        /// </para>
-        /// </summary>
-        /// <value>
-        /// A <see cref="String"/> representing the text displayed inside the button.
-        /// </value>
-        public string ButtonText { get; set; }
-        /// <summary>
-        /// Gets or sets the <see cref="GameControl"/> displayed inside the button, it changes depending on keybinds and whether the user is using the controller or the keyboard and mouse.
-        /// <para>
-        /// If <c>null</c> and <see cref="ButtonText"/> is also <c>null</c> an empty button is displayed.
-        /// </para>
-        /// <para>
-        /// If this <see cref="InstructionalButton"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
-        /// <see cref="InstructionalButtons.Update"/> needs to be called to reflect the changes made.
-        /// </para>
-        /// </summary>
-        /// <value>
-        /// A <see cref="GameControl"/> representing the binding displayed inside the button.
-        /// </value>
-        public GameControl? ButtonControl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Predicate{InstructionalButton}"/> delegate that defines the conditions for this <see cref="InstructionalButton"/> to be visible.
-        /// <para>
-        /// If this <see cref="InstructionalButton"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
+        /// If this <see cref="IInstructionalButtonSlot"/> is contained in a <see cref="InstructionalButtons"/> scaleform, 
         /// this predicate is only evaluated when <see cref="InstructionalButtons.Update"/> is called.
         /// </para>
         /// </summary>
         /// <value>
-        /// A <see cref="Predicate{InstructionalButton}"/> delegate that defines the conditions for this <see cref="InstructionalButton"/> to be visible.
+        /// A <see cref="Predicate{T}"/> delegate that defines the conditions for this <see cref="InstructionalButton"/> to be visible.
         /// </value>
-        public Predicate<InstructionalButton> CanBeDisplayed { get; set; }
+        public Predicate<IInstructionalButtonSlot> CanBeDisplayed { get; set; }
+
+        /// <summary>
+        /// Gets a <see cref="string"/> that represents the contents of this <see cref="IInstructionalButtonSlot"/>.
+        /// </summary>
+        /// <returns>A <see cref="string"/> that represents the contents of this <see cref="IInstructionalButtonSlot"/>.</returns>
+        public string GetButtonId();
+    }
+
+    public class InstructionalButton : IInstructionalButtonSlot
+    {
+        /// <inheritdoc/>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contents of the button.
+        /// </summary>
+        public InstructionalButtonId Button { get; set; }
+
+        /// <inheritdoc/>
+        public Predicate<IInstructionalButtonSlot> CanBeDisplayed { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
+        /// </summary>
+        /// <param name="button">The button to be displayed.</param>
+        /// <param name="text">The text displayed next to the button.</param>
+        public InstructionalButton(InstructionalButtonId button, string text)
+        {
+            Text = text;
+            Button = button;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
         /// </summary>
         /// <param name="control">The <see cref="GameControl"/> displayed inside the button, it changes depending on keybinds and whether the user is using the controller or the keyboard and mouse.</param>
         /// <param name="text">The text displayed next to the button.</param>
-        public InstructionalButton(GameControl control, string text)
-        {
-            Text = text;
-            ButtonControl = control;
-        }
+        public InstructionalButton(GameControl control, string text) : this((InstructionalButtonId)control, text) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
         /// </summary>
         /// <param name="buttonText">The text displayed inside the button, mainly for displaying custom keyboard bindings, like "I", or "O", or "F5".</param>
         /// <param name="text">The text displayed next to the button.</param>
-        public InstructionalButton(string buttonText, string text)
+        public InstructionalButton(string buttonText, string text) : this((InstructionalButtonId)buttonText, text) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
+        /// </summary>
+        /// <param name="rawId">The raw identifier of the symbol to be displayed.</param>
+        /// <param name="text">The text displayed next to the button.</param>
+        public InstructionalButton(uint rawId, string text) : this((InstructionalButtonId)rawId, text) { }
+
+        /// <inheritdoc/>
+        public string GetButtonId() => Button.Id;
+
+        public static string GetButtonId(GameControl control) => new InstructionalButtonId(control).Id;
+        public static string GetButtonId(string keyString) => new InstructionalButtonId(keyString).Id;
+        public static string GetButtonId(uint rawId) => new InstructionalButtonId(rawId).Id;
+    }
+
+    public class InstructionalButtonGroup : IInstructionalButtonSlot
+    {
+        private IList<InstructionalButtonId> buttons;
+
+        /// <inheritdoc/>
+        public string Text { get; set; }
+
+        /// <inheritdoc/>
+        public Predicate<IInstructionalButtonSlot> CanBeDisplayed { get; set; }
+
+        public IList<InstructionalButtonId> Buttons
+        {
+            get => buttons;
+            set => buttons = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public InstructionalButtonGroup(IEnumerable<InstructionalButtonId> buttons, string text)
         {
             Text = text;
-            ButtonText = buttonText;
-        }
-        
-        public string GetButtonId()
-        {
-            return ButtonText == null ? (ButtonControl.HasValue ? GetButtonId(ButtonControl.Value) : GetButtonId("")) : GetButtonId(ButtonText);
+            Buttons = new List<InstructionalButtonId>(buttons);
         }
 
-        public static string GetButtonId(GameControl control) => N.GetControlInstructionalButton(2, control);
+        public InstructionalButtonGroup(IEnumerable<GameControl> controls, string text) : this(controls.Select(x => (InstructionalButtonId)x), text) { }
 
-        public static string GetButtonId(string keyString)
-            => keyString.Length switch
+        public InstructionalButtonGroup(IEnumerable<string> buttonTexts, string text) : this(buttonTexts.Select(x => (InstructionalButtonId)x), text) { }
+
+        public InstructionalButtonGroup(IEnumerable<uint> rawIds, string text) : this(rawIds.Select(x => (InstructionalButtonId)x), text) { }
+
+        /// <inheritdoc/>
+        public string GetButtonId() => GetButtonId(Buttons);
+
+        public static string GetButtonId(IEnumerable<InstructionalButtonId> buttons)
+            => buttons.Reverse().Aggregate("", (acc, btn) => acc + (acc.Length == 0 ? "" : "%") + btn.Id);
+    }
+
+    public readonly struct InstructionalButtonId
+    {
+        /// <summary>
+        /// A blank button. Used when this struct is created with the default constructor or <c>default</c> value.
+        /// </summary>
+        private const string EmptyButtonId = "t_";
+
+        // need to store the control because the string returned by GET_CONTROL_INSTRUCTIONAL_BUTTON may change
+        // if the user switches between keyboard and controller
+        private readonly GameControl? control;
+        private readonly string id;
+
+        /// <summary>
+        /// Gets the string that represents the button contents.
+        /// </summary>
+        public string Id => id ?? (control.HasValue ? N.GetControlInstructionalButton(2, control.Value)  : EmptyButtonId);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonId"/> structure.
+        /// </summary>
+        /// <param name="control">The <see cref="GameControl"/> displayed inside the button, it changes depending on keybinds and whether the user is using the controller or the keyboard and mouse.</param>
+        public InstructionalButtonId(GameControl control) : this() => this.control = control;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonId"/> structure.
+        /// </summary>
+        /// <param name="str">The text displayed inside the button, mainly for displaying custom keyboard bindings, like "I", or "O", or "F5".</param>
+        public InstructionalButtonId(string str) : this()
+            => id = str.Length switch
             {
                 int n when n <= 2 => "t_",
                 int n when n <= 4 => "T_",
                 _ => "w_"
-            } + keyString;
+            } + str;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonId"/> structure.
+        /// </summary>
+        /// <param name="rawId">The raw identifier of the symbol to be displayed.</param>
+        public InstructionalButtonId(uint rawId) : this() => id = "b_" + rawId;
+
+        public static implicit operator InstructionalButtonId(GameControl control) => new InstructionalButtonId(control);
+        public static implicit operator InstructionalButtonId(string str) => new InstructionalButtonId(str);
+        public static implicit operator InstructionalButtonId(uint rawId) => new InstructionalButtonId(rawId);
     }
 }
-

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -8,7 +8,11 @@ namespace RAGENativeUI.Elements
 
     public class InstructionalButtons
     {
+        private const string ScaleformName = "instructional_buttons";
+
         public static readonly Color DefaultBackgroundColor = Color.FromArgb(80, 0, 0, 0);
+
+        private bool needsUpdate = true;
 
         public Scaleform Scaleform { get; }
         public InstructionalButtonsCollection Buttons { get; }
@@ -16,8 +20,7 @@ namespace RAGENativeUI.Elements
 
         public InstructionalButtons()
         {
-            Scaleform = new Scaleform(0);
-            Scaleform.Load("instructional_buttons");
+            Scaleform = new Scaleform();
 
             Buttons = new InstructionalButtonsCollection();
             Buttons.ItemAdded += (c, i) => Update();
@@ -28,11 +31,24 @@ namespace RAGENativeUI.Elements
 
         public void Draw()
         {
+            if (needsUpdate)
+            {
+                DoUpdate();
+            }
+
             Scaleform.Render2D();
         }
 
-        public void Update()
+        public void Update() => needsUpdate = true;
+
+        private void DoUpdate()
         {
+            if (!Scaleform.IsLoaded)
+            {
+                Scaleform.Load(ScaleformName);
+                return;
+            }
+
             Scaleform.CallFunction("CLEAR_ALL");
             Scaleform.CallFunction("TOGGLE_MOUSE_BUTTONS", 0);
 
@@ -47,8 +63,9 @@ namespace RAGENativeUI.Elements
 
             Scaleform.CallFunction("SET_BACKGROUND_COLOUR", (int)BackgroundColor.R, (int)BackgroundColor.G, (int)BackgroundColor.B, (int)BackgroundColor.A);
             Scaleform.CallFunction("DRAW_INSTRUCTIONAL_BUTTONS", -1);
-        }
 
+            needsUpdate = false;
+        }
 
         public class InstructionalButtonsCollection : BaseCollection<IInstructionalButtonSlot>
         {

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -106,9 +106,6 @@ namespace RAGENativeUI.Elements
         /// </value>
         public Predicate<InstructionalButton> CanBeDisplayed { get; set; }
 
-        [Obsolete("ItemBind is obsolete. Check BindToItem(UIMenuItem) for details.")]
-        public UIMenuItem ItemBind { get; private set; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
         /// </summary>
@@ -129,17 +126,6 @@ namespace RAGENativeUI.Elements
         {
             Text = text;
             ButtonText = buttonText;
-        }
-
-        /// <summary>
-        /// Bind this button to an item, so it's only shown when that item is selected.
-        /// </summary>
-        /// <param name="item">Item to bind to.</param>
-        [Obsolete("BindToItem(UIMenuItem) is obsolete. Use CanBeDisplayed predicate instead, checking for UIMenuItem.Selected.")]
-        public void BindToItem(UIMenuItem item)
-        {
-            ItemBind = item;
-            CanBeDisplayed = (i) => item.Selected;
         }
         
         public string GetButtonId()

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -147,10 +147,7 @@ namespace RAGENativeUI.Elements
             return ButtonText == null ? (ButtonControl.HasValue ? GetButtonId(ButtonControl.Value) : GetButtonId("")) : GetButtonId(ButtonText);
         }
 
-        public static string GetButtonId(GameControl control)
-        {
-            return NativeFunction.Natives.GET_CONTROL_INSTRUCTIONAL_BUTTON<string>(2, (int)control, 0);
-        }
+        public static string GetButtonId(GameControl control) => N.GetControlInstructionalButton(2, control);
 
         public static string GetButtonId(string keyString)
             => keyString.Length switch

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -50,14 +50,18 @@ namespace RAGENativeUI.Elements
             }
 
             Scaleform.CallFunction("CLEAR_ALL");
-            Scaleform.CallFunction("TOGGLE_MOUSE_BUTTONS", 0);
+            Scaleform.CallFunction("TOGGLE_MOUSE_BUTTONS", true);
 
             for (int i = 0, slot = 0; i < Buttons.Count; i++)
             {
                 IInstructionalButtonSlot b = Buttons[i];
                 if (b.CanBeDisplayed == null || b.CanBeDisplayed(b))
                 {
-                    Scaleform.CallFunction("SET_DATA_SLOT", slot++, b.GetButtonId() ?? string.Empty, b.Text ?? string.Empty);
+                    Scaleform.CallFunction("SET_DATA_SLOT", slot++,
+                                           b.GetButtonId() ?? string.Empty,
+                                           b.Text ?? string.Empty,
+                                           b.BindedControl.HasValue, // clickable?
+                                           b.BindedControl.HasValue ? (int)b.BindedControl.Value : - 1); // control binded to click
                 }
             }
 
@@ -99,6 +103,11 @@ namespace RAGENativeUI.Elements
         public Predicate<IInstructionalButtonSlot> CanBeDisplayed { get; set; }
 
         /// <summary>
+        /// Gets or sets the <see cref="GameControl"/> triggered when the button is clicked. If <c>null</c>, the button cannot be clicked.
+        /// </summary>
+        public GameControl? BindedControl { get; set; }
+
+        /// <summary>
         /// Gets a <see cref="string"/> that represents the contents of this <see cref="IInstructionalButtonSlot"/>.
         /// </summary>
         /// <returns>A <see cref="string"/> that represents the contents of this <see cref="IInstructionalButtonSlot"/>.</returns>
@@ -121,7 +130,10 @@ namespace RAGENativeUI.Elements
 
         /// <inheritdoc/>
         public Predicate<IInstructionalButtonSlot> CanBeDisplayed { get; set; }
-
+        
+        /// <inheritdoc/>
+        public GameControl? BindedControl { get; set; }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
         /// </summary>
@@ -134,11 +146,11 @@ namespace RAGENativeUI.Elements
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
+        /// Initializes a new instance of the <see cref="InstructionalButton"/> class. This overload sets <see cref="BindedControl"/> to <paramref name="control"/>.
         /// </summary>
         /// <param name="control">The <see cref="GameControl"/> displayed inside the button, it changes depending on keybinds and whether the user is using the controller or the keyboard and mouse.</param>
         /// <param name="text">The text displayed next to the button.</param>
-        public InstructionalButton(GameControl control, string text) : this((InstructionalButtonId)control, text) { }
+        public InstructionalButton(GameControl control, string text) : this((InstructionalButtonId)control, text) { BindedControl = control; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
@@ -171,6 +183,9 @@ namespace RAGENativeUI.Elements
 
         /// <inheritdoc/>
         public Predicate<IInstructionalButtonSlot> CanBeDisplayed { get; set; }
+
+        /// <inheritdoc/>
+        public GameControl? BindedControl { get; set; }
 
         /// <summary>
         /// Gets or sets the list containing the buttons of this group.

--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -105,6 +105,9 @@ namespace RAGENativeUI.Elements
         /// <summary>
         /// Gets or sets the <see cref="GameControl"/> triggered when the button is clicked. If <c>null</c>, the button cannot be clicked.
         /// </summary>
+        /// <remarks>
+        /// When the user clicks the button, the specified control will be pressed for one frame so it can be checked with methods such as <see cref="Game.IsControlJustPressed(int, GameControl)"/>.
+        /// </remarks>
         public GameControl? BindedControl { get; set; }
 
         /// <summary>

--- a/Source/Elements/MissionPassedScreen.cs
+++ b/Source/Elements/MissionPassedScreen.cs
@@ -89,7 +89,7 @@ namespace RAGENativeUI.Elements
                     int index = InstructionalButtons.Buttons.IndexOf(continueControlInstructionalButton);
                     if (index != -1)
                     {
-                        InstructionalButtons.Buttons[index].ButtonControl = continueControl;
+                        continueControlInstructionalButton.Button = continueControl;
                     }
                     InstructionalButtons.Update();
                 }

--- a/Source/Elements/Scaleform.cs
+++ b/Source/Elements/Scaleform.cs
@@ -7,10 +7,10 @@ namespace RAGENativeUI.Elements
 {
     public class Scaleform
     {
-        private int _handle;
-        private string _scaleformID;
+        public const int InvalidHandle = 0;
 
-        public int Handle { get { return _handle; } }
+        public int Handle { get; private set; } = InvalidHandle;
+        public bool IsLoaded => Handle != InvalidHandle && N.HasScaleformMovieLoaded(Handle);
 
         public Scaleform()
         {
@@ -18,26 +18,21 @@ namespace RAGENativeUI.Elements
 
         public Scaleform(int handle)
         {
-            this._handle = handle;
+            this.Handle = handle;
         }
 
         public bool Load(string scaleformID)
         {
-            int handle = NativeFunction.Natives.RequestScaleformMovie<int>(scaleformID);
+            Handle = N.RequestScaleformMovie(scaleformID);
 
-            if (handle == 0) return false;
-
-            this._handle = handle;
-            this._scaleformID = scaleformID;
-
-            return true;
+            return Handle != InvalidHandle;
         }
 
 
         public void Render2D()
         {
             const ulong DrawScaleformMovieDefault = 0x0df606929c105be1;         
-            NativeFunction.CallByHash<uint>(DrawScaleformMovieDefault, this.Handle, 255, 255, 255, 255);
+            NativeFunction.CallByHash<uint>(DrawScaleformMovieDefault, Handle, 255, 255, 255, 255);
         }
         public void Render2DScreenSpace(PointF location, PointF size)
         {
@@ -46,17 +41,17 @@ namespace RAGENativeUI.Elements
             float width = size.X / 1280.0f;
             float height = size.Y / 720.0f;
 
-            NativeFunction.Natives.DrawScaleformMovie(this._handle, x + (width / 2.0f), y + (height / 2.0f), width, height, 255, 255, 255, 255);
+            NativeFunction.Natives.DrawScaleformMovie(Handle, x + (width / 2.0f), y + (height / 2.0f), width, height, 255, 255, 255, 255);
         }
 
 
         public void Render3D(Vector3 position, Vector3 rotation, Vector3 scale)
         {
-		    NativeFunction.CallByHash<uint>(0x1ce592fdc749d6f5, this._handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
+		    NativeFunction.CallByHash<uint>(0x1ce592fdc749d6f5, Handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
         }
         public void Render3DAdditive(Vector3 position, Vector3 rotation, Vector3 scale)
         {
-            NativeFunction.CallByHash<uint>(0x87d51d72255d4e78, this._handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
+            NativeFunction.CallByHash<uint>(0x87d51d72255d4e78, Handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
         }
 
 
@@ -73,7 +68,7 @@ namespace RAGENativeUI.Elements
             const ulong PopScaleformMovieFunctionVoidHash = 0xc6796a8ffa375e53;
 
 
-            NativeFunction.CallByHash<uint>(PushScaleformMovieFunctionHash, this._handle, function);
+            NativeFunction.CallByHash<uint>(PushScaleformMovieFunctionHash, Handle, function);
 
             foreach (object obj in arguments)
             {
@@ -111,7 +106,7 @@ namespace RAGENativeUI.Elements
                 }
                 else
                 {
-                    Game.LogTrivial(String.Format("Unknown argument type {0} passed to scaleform with handle {1}.", obj.GetType().Name, this._handle));
+                    Game.LogTrivial(String.Format("Unknown argument type {0} passed to scaleform with handle {1}.", obj.GetType().Name, Handle));
                 }
             }
             

--- a/Source/Natives.cs
+++ b/Source/Natives.cs
@@ -125,6 +125,7 @@
         public static void DisableAllControlActions(int index) => Natives.DisableAllControlActions(index);
         public static float GetControlNormal(int index, GameControl control) => Natives.GetControlNormal<float>(index, (int)control);
         public static void SetInputExclusive(int index, GameControl control) => Natives.xEDE476E5EE29EDB1(index, (int)control);
+        public static string GetControlInstructionalButton(int index, GameControl control) => Natives.x0499D7B09FC9B407<string>(index, (int)control, true);
 
         public static void SetMouseCursorActiveThisFrame() => Natives.xAAE7CE1D63167423();
         public static void SetMouseCursorSprite(int spriteId) => Natives.x8DB8CFFD58B62552(spriteId);

--- a/Source/Natives.cs
+++ b/Source/Natives.cs
@@ -142,6 +142,9 @@
         public static void x5B73C77D9EB66E24(bool value) => Natives.x5B73C77D9EB66E24(value);
 
         public static int GetNumberOfReferencesOfScript(uint nameHash) => Natives.x2C83A9DA6BFFC4F9<int>(nameHash);
+
+        public static bool HasScaleformMovieLoaded(int handle) => Natives.x85F01B8D5B90570E<bool>(handle);
+        public static int RequestScaleformMovie(string name) => Natives.x11FE353CF9733E6F<int>(name);
     }
 }
 

--- a/Source/Natives.cs
+++ b/Source/Natives.cs
@@ -134,6 +134,7 @@
         public static void SetGameplayCamRelativeHeading(float heading) => Natives.SetGameplayCamRelativeHeading(heading);
 
         public static bool IsInputDisabled(int index) => Natives.xA571D46727E2B718<bool>(index);
+        public static bool HasInputJustChanged(int index) => Natives.x6CD79468A1E595C6<bool>(index);
 
         /// <summary>
         /// If true, in multiple-screens setups, limits the range of GameControl.CursorX to only the main screen.

--- a/Source/UIMenu.cs
+++ b/Source/UIMenu.cs
@@ -669,7 +669,15 @@ namespace RAGENativeUI
                 EnableCameraMovement();
 
             if (InstructionalButtonsEnabled)
+            {
+                if (N.HasInputJustChanged(2))
+                {
+                    // update to display the correct keys or controller buttons when the user switches between keyboard and controller
+                    InstructionalButtons.Update();
+                }
+
                 InstructionalButtons.Draw();
+            }
 
             UpdateScreenVars();
 
@@ -1320,7 +1328,6 @@ namespace RAGENativeUI
                         CurrentSelection = hoveredItem;
                         Common.PlaySound(AUDIO_UPDOWN, AUDIO_LIBRARY);
                         IndexChange(CurrentSelection);
-                        InstructionalButtons.Update();
                     }
                 }
                 else if (hoveredItem == -1)
@@ -1337,7 +1344,6 @@ namespace RAGENativeUI
                         {
                             GoDown();
                         }
-                        InstructionalButtons.Update();
                     }
 
                     if (MouseEdgeEnabled)


### PR DESCRIPTION
Text buttons choose between `t_`, `T_` and `w_` based on text length.
Added support for raw id buttons (`b_`), button groups (`InstructionalButtonGroup` class) and clickable buttons (`IInstructionalButtonSlot.BindedControl` property).
Added `InstructionalButtons.BackgroundColor` property.
Removed obsolete members.

Closes #52.