### PR TITLE
Implement token parser for arbitrary key icons

### DIFF
--- a/Source/Elements/InstructionalButtons.cs
+++ b/Source/Elements/InstructionalButtons.cs
@@ -254,12 +254,20 @@ namespace RAGENativeUI.Elements
         /// <param name="text">The text displayed next to the button.</param>
         public InstructionalButton(uint rawId, string text) : this((InstructionalButtonId)rawId, text) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButton"/> class.
+        /// </summary>
+        /// <param name="key">The symbol to be displayed.</param>
+        /// <param name="text">The text displayed next to the button.</param>
+        public InstructionalButton(InstructionalKey key, string text) : this((InstructionalButtonId)key, text) { }
+
         /// <inheritdoc/>
         public string GetButtonId() => Button.Id;
 
         public static string GetButtonId(GameControl control) => new InstructionalButtonId(control).Id;
         public static string GetButtonId(string keyString) => new InstructionalButtonId(keyString).Id;
         public static string GetButtonId(uint rawId) => new InstructionalButtonId(rawId).Id;
+        public static string GetButtonId(InstructionalKey key) => new InstructionalButtonId(key).Id;
     }
 
     public class InstructionalButtonGroup : IInstructionalButtonSlot
@@ -357,8 +365,15 @@ namespace RAGENativeUI.Elements
         /// <param name="rawId">The raw identifier of the symbol to be displayed.</param>
         public InstructionalButtonId(uint rawId) : this() => id = "b_" + rawId;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionalButtonId"/> structure.
+        /// </summary>
+        /// <param name="key">The symbol to be displayed.</param>
+        public InstructionalButtonId(InstructionalKey key) : this() => id = key.GetId();
+
         public static implicit operator InstructionalButtonId(GameControl control) => new InstructionalButtonId(control);
         public static implicit operator InstructionalButtonId(string str) => new InstructionalButtonId(str);
         public static implicit operator InstructionalButtonId(uint rawId) => new InstructionalButtonId(rawId);
+        public static implicit operator InstructionalButtonId(InstructionalKey key) => new InstructionalButtonId(key);
     }
 }

--- a/Source/Elements/InstructionalKey.cs
+++ b/Source/Elements/InstructionalKey.cs
@@ -21,11 +21,13 @@
                        IOMS_MOUSE_ABSOLUTEAXIS = 1,
                        IOMS_MOUSE_WHEEL = 6,
                        IOMS_MOUSE_BUTTON = 7,
-                       IOMS_PAD_DIGITALBUTTON = 9;
+                       IOMS_PAD_DIGITALBUTTON = 9,
+                       IOMS_PAD_AXIS = 12;
 
             const uint MouseAxisMask = 0x200,
                        MouseWheelMask = 0x400,
                        MouseButtonMask = 0x800,
+                       ControllerAxisMask = 0x1000,
                        ControllerButtonMask = 0x2000;
 
             atFixedArray_sIconData_4 icons = default;
@@ -33,6 +35,7 @@
             uint source = (parameter & MouseAxisMask) != 0 ? IOMS_MOUSE_ABSOLUTEAXIS :
                           (parameter & MouseWheelMask) != 0 ? IOMS_MOUSE_WHEEL : 
                           (parameter & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON :
+                          (parameter & ControllerAxisMask) != 0 ? IOMS_PAD_AXIS :
                           (parameter & ControllerButtonMask) != 0 ? IOMS_PAD_DIGITALBUTTON :
                                                                     IOMS_KEYBOARD;
 
@@ -357,19 +360,19 @@
 
         MouseAxisX = 0x200, // IOM_AXIS_X
         MouseAxisY = 0x201, // IOM_AXIS_Y
-        //IOM_IAXIS_X = 0x202, // same symbol as IOM_AXIS_*
+        //IOM_IAXIS_X = 0x202, // same icon as IOM_AXIS_*
         //IOM_IAXIS_Y = 0x203,
-        //BASIC_MOUSE_AXIS_MAX = 0x204, // not a symbol
+        //BASIC_MOUSE_AXIS_MAX = 0x204, // not an icon
         MouseAxisXLeft = 0x205, // IOM_AXIS_X_LEFT
         MouseAxisXRight = 0x206, // IOM_AXIS_X_RIGHT
         MouseAxisYUp = 0x207, // IOM_AXIS_Y_UP
         MouseAxisYDown = 0x208, // IOM_AXIS_Y_DOWN
-        //MOUSE_AXIS_MAX = 0x209, // not a symbol
+        //MOUSE_AXIS_MAX = 0x209, // not an icon
 
         MouseWheelUp = 0x400, // IOM_WHEEL_UP
         MouseWheelDown = 0x401, // IOM_WHEEL_DOWN
         MouseWheel = 0x402, // IOM_AXIS_WHEEL_DELTA
-        // these have the same symbol as IOM_AXIS_WHEEL_DELTA
+        // these have the same icon as IOM_AXIS_WHEEL_DELTA
         //IOM_IAXIS_WHEEL_DELTA = 0x403,
         //IOM_AXIS_WHEEL = 0x404,
         //IOM_IAXIS_WHEEL = 0x405,
@@ -384,6 +387,37 @@
         MouseExtra3 = 0x820,
         MouseExtra4 = 0x840,
         MouseExtra5 = 0x880,
+
+        ControllerAxisLX = 0x1000, // IOM_AXIS_LX
+        ControllerAxisLY = 0x1001, // IOM_AXIS_LY
+        ControllerAxisRX = 0x1002, // IOM_AXIS_RX
+        ControllerAxisRY = 0x1003, // IOM_AXIS_RY
+        // IOM_AXIS_LUP = 0x1004, // these don't have icons
+        // IOM_AXIS_LDOWN = 0x1005,
+        // IOM_AXIS_LLEFT = 0x1006,
+        // IOM_AXIS_LRIGHT = 0x1007,
+        // IOM_AXIS_LUR = 0x1008,
+        // IOM_AXIS_LUL = 0x1009,
+        // IOM_AXIS_LDR = 0x100A,
+        // IOM_AXIS_LDL = 0x100B,
+        // IOM_AXIS_RUP = 0x100C,
+        // IOM_AXIS_RDOWN = 0x100D,
+        // IOM_AXIS_RLEFT = 0x100E,
+        // IOM_AXIS_RRIGHT = 0x100F,
+        // IOM_AXIS_RUR = 0x1010,
+        // IOM_AXIS_RUL = 0x1011,
+        // IOM_AXIS_RDR = 0x1012,
+        // IOM_AXIS_RDL = 0x1013,
+        // IOM_AXIS_DPADX = 0x1014,
+        // IOM_AXIS_DPADY = 0x1015,
+        ControllerAxisLYUp = 0x1016, // IOM_AXIS_LY_UP
+        ControllerAxisLYDown = 0x1017, // IOM_AXIS_LY_DOWN
+        ControllerAxisLXLeft = 0x1018, // IOM_AXIS_LX_LEFT
+        ControllerAxisLXRight = 0x1019, // IOM_AXIS_LX_RIGHT
+        ControllerAxisRYUp = 0x101A, // IOM_AXIS_RY_UP
+        ControllerAxisRYDown = 0x101B, // IOM_AXIS_RY_DOWN
+        ControllerAxisRXLeft = 0x101C, // IOM_AXIS_RX_LEFT
+        ControllerAxisRXRight = 0x101D, // IOM_AXIS_RX_RIGHT
 
         ControllerLTrigger = 0x2000, // L2_INDEX
         ControllerRTrigger = 0x2001, // R2_INDEX

--- a/Source/Elements/InstructionalKey.cs
+++ b/Source/Elements/InstructionalKey.cs
@@ -3,6 +3,8 @@
     using System.Text;
     using System.Windows.Forms;
 
+    using Rage;
+
     using RAGENativeUI.Internals;
 
     public static class InstructionalKeyExtensions
@@ -17,11 +19,23 @@
             // from rage::ioMapperSource enum
             const uint IOMS_KEYBOARD = 0;
             const uint IOMS_MOUSE_BUTTON = 7;
+            const uint IOMS_PAD_DIGITALBUTTON = 9;
 
             const uint MouseButtonMask = 0x800;
+            const uint ControllerButtonMask = 0x2000;
 
             atFixedArray_sIconData_4 icons = default;
-            CTextFormat.GetInputSourceIcons(((uint)key & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON : IOMS_KEYBOARD, (uint)key, ref icons);
+            uint source = ((uint)key & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON :
+                          ((uint)key & ControllerButtonMask) != 0 ? IOMS_PAD_DIGITALBUTTON :
+                                                                    IOMS_KEYBOARD;
+            uint parameter = (uint)key;
+
+            if (source == IOMS_PAD_DIGITALBUTTON)
+            {
+                parameter = 1u << (int)(parameter & 0xFFu);
+            }
+
+            CTextFormat.GetInputSourceIcons(source, parameter, ref icons);
 
             const int BufferSize = 64;
             byte* buffer = stackalloc byte[BufferSize];
@@ -167,6 +181,30 @@
                 Keys.Oem7 => InstructionalKey.Oem7,
                 Keys.Oem102 => InstructionalKey.Oem102,
                 _ => InstructionalKey.Unknown
+            };
+
+
+
+        public static string GetInstructionalId(this ControllerButtons button) => button.GetInstructionalKey().GetId();
+
+        public static InstructionalKey GetInstructionalKey(this ControllerButtons button)
+            => button switch
+            {
+                ControllerButtons.DPadUp => InstructionalKey.ControllerDPadUp,
+                ControllerButtons.DPadDown => InstructionalKey.ControllerDPadDown,
+                ControllerButtons.DPadLeft => InstructionalKey.ControllerDPadLeft,
+                ControllerButtons.DPadRight => InstructionalKey.ControllerDPadRight,
+                ControllerButtons.Start => InstructionalKey.ControllerStart,
+                ControllerButtons.Back => InstructionalKey.ControllerBack,
+                ControllerButtons.LeftThumb => InstructionalKey.ControllerLThumb,
+                ControllerButtons.RightThumb => InstructionalKey.ControllerRThumb,
+                ControllerButtons.LeftShoulder => InstructionalKey.ControllerLShoulder,
+                ControllerButtons.RightShoulder => InstructionalKey.ControllerRShoulder,
+                ControllerButtons.A => InstructionalKey.ControllerA,
+                ControllerButtons.B => InstructionalKey.ControllerB,
+                ControllerButtons.X => InstructionalKey.ControllerX,
+                ControllerButtons.Y => InstructionalKey.ControllerY,
+                _ => InstructionalKey.Unknown,
             };
     }
 
@@ -319,5 +357,33 @@
         MouseExtra3 = 0x820,
         MouseExtra4 = 0x840,
         MouseExtra5 = 0x880,
+
+        ControllerLTrigger = 0x2000, // L2_INDEX
+        ControllerRTrigger = 0x2001, // R2_INDEX
+        ControllerLShoulder = 0x2002, // L1_INDEX
+        ControllerRShoulder = 0x2003, // R1_INDEX
+        ControllerRUp = 0x2004, // RUP_INDEX
+        ControllerRRight = 0x2005, // RRIGHT_INDEX
+        ControllerRDown = 0x2006, // RDOWN_INDEX
+        ControllerRLeft = 0x2007, // RLEFT_INDEX
+        ControllerSelect = 0x2008, // SELECT_INDEX
+        ControllerLThumb = 0x2009, // L3_INDEX
+        ControllerRThumb = 0x200A, // R3_INDEX
+        ControllerStart = 0x200B, // START_INDEX
+        ControllerLUp = 0x200C, // LUP_INDEX
+        ControllerLRight = 0x200D, // LRIGHT_INDEX
+        ControllerLDown = 0x200E, // LDOWN_INDEX
+        ControllerLLeft = 0x200F, // LLEFT_INDEX
+
+        // aliases to have the same names as RPH's ControllerButtons enum
+        ControllerBack = ControllerSelect,
+        ControllerDPadDown = ControllerLDown,
+        ControllerDPadRight = ControllerLRight,
+        ControllerDPadLeft = ControllerLLeft,
+        ControllerDPadUp = ControllerLUp,
+        ControllerA = ControllerRDown,
+        ControllerB = ControllerRRight,
+        ControllerX = ControllerRLeft,
+        ControllerY = ControllerRUp,
     }
 }

--- a/Source/Elements/InstructionalKey.cs
+++ b/Source/Elements/InstructionalKey.cs
@@ -11,6 +11,26 @@
     {
         public static unsafe string GetId(this InstructionalKey key)
         {
+            // special cases
+            switch (key)
+            {
+                case InstructionalKey.ControllerDPadNone: return "b_8";
+                case InstructionalKey.ControllerDPadAll: return "b_9";
+                case InstructionalKey.ControllerDPadUpDown: return "b_10";
+                case InstructionalKey.ControllerDPadLeftRight: return "b_11";
+                case InstructionalKey.ControllerLStickRotate: return "b_20";
+                case InstructionalKey.ControllerRStickRotate: return "b_29";
+                case InstructionalKey.SymbolBusySpinner: return "b_44";
+                case InstructionalKey.SymbolPlus: return "b_998";
+                case InstructionalKey.SymbolArrowUp: return "b_0";
+                case InstructionalKey.SymbolArrowDown: return "b_1";
+                case InstructionalKey.SymbolArrowLeft: return "b_2";
+                case InstructionalKey.SymbolArrowRight: return "b_3";
+                case InstructionalKey.SymbolArrowUpDown: return "b_45";
+                case InstructionalKey.SymbolArrowLeftRight: return "b_46";
+                case InstructionalKey.SymbolArrowAll: return "b_47";
+            }
+
             if (!CTextFormat.Available)
             {
                 return "b_995"; // button with "???" in red
@@ -429,7 +449,9 @@
         ControllerRLeft = 0x2007, // RLEFT_INDEX
         ControllerSelect = 0x2008, // SELECT_INDEX
         ControllerLThumb = 0x2009, // L3_INDEX
+        ControllerLStick = ControllerLThumb,
         ControllerRThumb = 0x200A, // R3_INDEX
+        ControllerRStick = ControllerRThumb,
         ControllerStart = 0x200B, // START_INDEX
         ControllerLUp = 0x200C, // LUP_INDEX
         ControllerLRight = 0x200D, // LRIGHT_INDEX
@@ -446,5 +468,24 @@
         ControllerB = ControllerRRight,
         ControllerX = ControllerRLeft,
         ControllerY = ControllerRUp,
+
+        // special cases, these don't belong to the original enum
+        ControllerDPadNone = 0x40000,
+        ControllerDPadAll = 0x40001,
+        ControllerDPadUpDown = 0x40002,
+        ControllerDPadLeftRight = 0x40003,
+        ControllerLThumbRotate = 0x40004,
+        ControllerLStickRotate = ControllerLThumbRotate,
+        ControllerRThumbRotate = 0x40005,
+        ControllerRStickRotate = ControllerRThumbRotate,
+        SymbolBusySpinner = 0x40006,
+        SymbolPlus = 0x40007,
+        SymbolArrowUp = 0x40008,
+        SymbolArrowDown = 0x40009,
+        SymbolArrowLeft = 0x4000A,
+        SymbolArrowRight = 0x4000B,
+        SymbolArrowUpDown = 0x4000C,
+        SymbolArrowLeftRight = 0x4000D,
+        SymbolArrowAll = 0x4000E,
     }
 }

--- a/Source/Elements/InstructionalKey.cs
+++ b/Source/Elements/InstructionalKey.cs
@@ -25,10 +25,10 @@
             const uint ControllerButtonMask = 0x2000;
 
             atFixedArray_sIconData_4 icons = default;
-            uint source = ((uint)key & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON :
-                          ((uint)key & ControllerButtonMask) != 0 ? IOMS_PAD_DIGITALBUTTON :
-                                                                    IOMS_KEYBOARD;
             uint parameter = (uint)key;
+            uint source = (parameter & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON :
+                          (parameter & ControllerButtonMask) != 0 ? IOMS_PAD_DIGITALBUTTON :
+                                                                    IOMS_KEYBOARD;
 
             if (source == IOMS_PAD_DIGITALBUTTON)
             {

--- a/Source/Elements/InstructionalKey.cs
+++ b/Source/Elements/InstructionalKey.cs
@@ -17,16 +17,22 @@
             }
 
             // from rage::ioMapperSource enum
-            const uint IOMS_KEYBOARD = 0;
-            const uint IOMS_MOUSE_BUTTON = 7;
-            const uint IOMS_PAD_DIGITALBUTTON = 9;
+            const uint IOMS_KEYBOARD = 0,
+                       IOMS_MOUSE_ABSOLUTEAXIS = 1,
+                       IOMS_MOUSE_WHEEL = 6,
+                       IOMS_MOUSE_BUTTON = 7,
+                       IOMS_PAD_DIGITALBUTTON = 9;
 
-            const uint MouseButtonMask = 0x800;
-            const uint ControllerButtonMask = 0x2000;
+            const uint MouseAxisMask = 0x200,
+                       MouseWheelMask = 0x400,
+                       MouseButtonMask = 0x800,
+                       ControllerButtonMask = 0x2000;
 
             atFixedArray_sIconData_4 icons = default;
             uint parameter = (uint)key;
-            uint source = (parameter & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON :
+            uint source = (parameter & MouseAxisMask) != 0 ? IOMS_MOUSE_ABSOLUTEAXIS :
+                          (parameter & MouseWheelMask) != 0 ? IOMS_MOUSE_WHEEL : 
+                          (parameter & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON :
                           (parameter & ControllerButtonMask) != 0 ? IOMS_PAD_DIGITALBUTTON :
                                                                     IOMS_KEYBOARD;
 
@@ -348,6 +354,27 @@
         NumPadEnter = 0xFD, // KEY_NUMPADENTER
         // KEY_CHATPAD_GREEN_SHIFT = 0xFE,
         // KEY_CHATPAD_ORANGE_SHIFT = 0xFF,
+
+        MouseAxisX = 0x200, // IOM_AXIS_X
+        MouseAxisY = 0x201, // IOM_AXIS_Y
+        //IOM_IAXIS_X = 0x202, // same symbol as IOM_AXIS_*
+        //IOM_IAXIS_Y = 0x203,
+        //BASIC_MOUSE_AXIS_MAX = 0x204, // not a symbol
+        MouseAxisXLeft = 0x205, // IOM_AXIS_X_LEFT
+        MouseAxisXRight = 0x206, // IOM_AXIS_X_RIGHT
+        MouseAxisYUp = 0x207, // IOM_AXIS_Y_UP
+        MouseAxisYDown = 0x208, // IOM_AXIS_Y_DOWN
+        //MOUSE_AXIS_MAX = 0x209, // not a symbol
+
+        MouseWheelUp = 0x400, // IOM_WHEEL_UP
+        MouseWheelDown = 0x401, // IOM_WHEEL_DOWN
+        MouseWheel = 0x402, // IOM_AXIS_WHEEL_DELTA
+        // these have the same symbol as IOM_AXIS_WHEEL_DELTA
+        //IOM_IAXIS_WHEEL_DELTA = 0x403,
+        //IOM_AXIS_WHEEL = 0x404,
+        //IOM_IAXIS_WHEEL = 0x405,
+        //IOM_AXIS_WHEEL_RELATIVE = 0x406,
+        //IOM_IAXIS_WHEEL_RELATIVE = 0x407,
 
         MouseLeft = 0x801,
         MouseRight = 0x802,

--- a/Source/Elements/InstructionalKey.cs
+++ b/Source/Elements/InstructionalKey.cs
@@ -1,0 +1,323 @@
+﻿namespace RAGENativeUI.Elements
+{
+    using System.Text;
+    using System.Windows.Forms;
+
+    using RAGENativeUI.Internals;
+
+    public static class InstructionalKeyExtensions
+    {
+        public static unsafe string GetId(this InstructionalKey key)
+        {
+            if (!CTextFormat.Available)
+            {
+                return "b_995"; // button with "???" in red
+            }
+
+            // from rage::ioMapperSource enum
+            const uint IOMS_KEYBOARD = 0;
+            const uint IOMS_MOUSE_BUTTON = 7;
+
+            const uint MouseButtonMask = 0x800;
+
+            atFixedArray_sIconData_4 icons = default;
+            CTextFormat.GetInputSourceIcons(((uint)key & MouseButtonMask) != 0 ? IOMS_MOUSE_BUTTON : IOMS_KEYBOARD, (uint)key, ref icons);
+
+            const int BufferSize = 64;
+            byte* buffer = stackalloc byte[BufferSize];
+            CTextFormat.GetIconListFormatString(ref icons, buffer, BufferSize);
+
+            return Encoding.UTF8.GetString(buffer, StrLen(buffer));
+
+            static int StrLen(byte* str)
+            {
+                int len = 0;
+                while (str[len] != 0) { len++; }
+                return len;
+            }
+        }
+
+        public static string GetInstructionalId(this Keys key) => key.GetInstructionalKey().GetId();
+
+        public static InstructionalKey GetInstructionalKey(this Keys key)
+            => key switch
+            {
+                Keys.LButton => InstructionalKey.MouseLeft,
+                Keys.RButton => InstructionalKey.MouseRight,
+                Keys.MButton => InstructionalKey.MouseMiddle,
+                Keys.XButton1 => InstructionalKey.MouseExtra1,
+                Keys.XButton2 => InstructionalKey.MouseExtra2,
+                Keys.Back => InstructionalKey.Back,
+                Keys.Tab => InstructionalKey.Tab,
+                Keys.Return => InstructionalKey.Return,
+                Keys.ShiftKey => InstructionalKey.LShift,
+                Keys.ControlKey => InstructionalKey.LControl,
+                Keys.Menu => InstructionalKey.LMenu,
+                Keys.Pause => InstructionalKey.Pause,
+                Keys.Capital => InstructionalKey.Capital,
+                Keys.Escape => InstructionalKey.Escape,
+                Keys.Space => InstructionalKey.Space,
+                Keys.PageUp => InstructionalKey.PageUp,
+                Keys.PageDown => InstructionalKey.PageDown,
+                Keys.End => InstructionalKey.End,
+                Keys.Home => InstructionalKey.Home,
+                Keys.Left => InstructionalKey.Left,
+                Keys.Up => InstructionalKey.Up,
+                Keys.Right => InstructionalKey.Right,
+                Keys.Down => InstructionalKey.Down,
+                Keys.Snapshot => InstructionalKey.Snapshot,
+                Keys.Insert => InstructionalKey.Insert,
+                Keys.Delete => InstructionalKey.Delete,
+                Keys.D0 => InstructionalKey.D0,
+                Keys.D1 => InstructionalKey.D1,
+                Keys.D2 => InstructionalKey.D2,
+                Keys.D3 => InstructionalKey.D3,
+                Keys.D4 => InstructionalKey.D4,
+                Keys.D5 => InstructionalKey.D5,
+                Keys.D6 => InstructionalKey.D6,
+                Keys.D7 => InstructionalKey.D7,
+                Keys.D8 => InstructionalKey.D8,
+                Keys.D9 => InstructionalKey.D9,
+                Keys.A => InstructionalKey.A,
+                Keys.B => InstructionalKey.B,
+                Keys.C => InstructionalKey.C,
+                Keys.D => InstructionalKey.D,
+                Keys.E => InstructionalKey.E,
+                Keys.F => InstructionalKey.F,
+                Keys.G => InstructionalKey.G,
+                Keys.H => InstructionalKey.H,
+                Keys.I => InstructionalKey.I,
+                Keys.J => InstructionalKey.J,
+                Keys.K => InstructionalKey.K,
+                Keys.L => InstructionalKey.L,
+                Keys.M => InstructionalKey.M,
+                Keys.N => InstructionalKey.N,
+                Keys.O => InstructionalKey.O,
+                Keys.P => InstructionalKey.P,
+                Keys.Q => InstructionalKey.Q,
+                Keys.R => InstructionalKey.R,
+                Keys.S => InstructionalKey.S,
+                Keys.T => InstructionalKey.T,
+                Keys.U => InstructionalKey.U,
+                Keys.V => InstructionalKey.V,
+                Keys.W => InstructionalKey.W,
+                Keys.X => InstructionalKey.X,
+                Keys.Y => InstructionalKey.Y,
+                Keys.Z => InstructionalKey.Z,
+                Keys.LWin => InstructionalKey.LWin,
+                Keys.RWin => InstructionalKey.RWin,
+                Keys.Apps => InstructionalKey.Apps,
+                Keys.NumPad0 => InstructionalKey.NumPad0,
+                Keys.NumPad1 => InstructionalKey.NumPad1,
+                Keys.NumPad2 => InstructionalKey.NumPad2,
+                Keys.NumPad3 => InstructionalKey.NumPad3,
+                Keys.NumPad4 => InstructionalKey.NumPad4,
+                Keys.NumPad5 => InstructionalKey.NumPad5,
+                Keys.NumPad6 => InstructionalKey.NumPad6,
+                Keys.NumPad7 => InstructionalKey.NumPad7,
+                Keys.NumPad8 => InstructionalKey.NumPad8,
+                Keys.NumPad9 => InstructionalKey.NumPad9,
+                Keys.Multiply => InstructionalKey.Multiply,
+                Keys.Add => InstructionalKey.Add,
+                Keys.Subtract => InstructionalKey.Subtract,
+                Keys.Decimal => InstructionalKey.Decimal,
+                Keys.Divide => InstructionalKey.Divide,
+                Keys.F1 => InstructionalKey.F1,
+                Keys.F2 => InstructionalKey.F2,
+                Keys.F3 => InstructionalKey.F3,
+                Keys.F4 => InstructionalKey.F4,
+                Keys.F5 => InstructionalKey.F5,
+                Keys.F6 => InstructionalKey.F6,
+                Keys.F7 => InstructionalKey.F7,
+                Keys.F8 => InstructionalKey.F8,
+                Keys.F9 => InstructionalKey.F9,
+                Keys.F10 => InstructionalKey.F10,
+                Keys.F11 => InstructionalKey.F11,
+                Keys.F12 => InstructionalKey.F12,
+                Keys.F13 => InstructionalKey.F13,
+                Keys.F14 => InstructionalKey.F14,
+                Keys.F15 => InstructionalKey.F15,
+                Keys.F16 => InstructionalKey.F16,
+                Keys.F17 => InstructionalKey.F17,
+                Keys.F18 => InstructionalKey.F18,
+                Keys.F19 => InstructionalKey.F19,
+                Keys.F20 => InstructionalKey.F20,
+                Keys.F21 => InstructionalKey.F21,
+                Keys.F22 => InstructionalKey.F22,
+                Keys.F23 => InstructionalKey.F23,
+                Keys.F24 => InstructionalKey.F24,
+                Keys.NumLock => InstructionalKey.NumLock,
+                Keys.Scroll => InstructionalKey.Scroll,
+                Keys.LShiftKey => InstructionalKey.LShift,
+                Keys.RShiftKey => InstructionalKey.RShift,
+                Keys.LControlKey => InstructionalKey.LControl,
+                Keys.RControlKey => InstructionalKey.RControl,
+                Keys.LMenu => InstructionalKey.LMenu,
+                Keys.RMenu => InstructionalKey.RMenu,
+                Keys.Oem1 => InstructionalKey.Oem1,
+                Keys.Oemplus => InstructionalKey.Plus,
+                Keys.Oemcomma => InstructionalKey.Comma,
+                Keys.OemMinus => InstructionalKey.Minus,
+                Keys.OemPeriod => InstructionalKey.Period,
+                Keys.Oem2 => InstructionalKey.Oem2,
+                Keys.Oem3 => InstructionalKey.Oem3,
+                Keys.Oem4 => InstructionalKey.Oem4,
+                Keys.Oem5 => InstructionalKey.Oem5,
+                Keys.Oem6 => InstructionalKey.Oem6,
+                Keys.Oem7 => InstructionalKey.Oem7,
+                Keys.Oem102 => InstructionalKey.Oem102,
+                _ => InstructionalKey.Unknown
+            };
+    }
+
+    public enum InstructionalKey // from rage::ioMapperParameter enum
+    {
+        Unknown = 0x0, // KEY_NULL
+        Back = 0x8, // KEY_BACK
+        Tab = 0x9, // KEY_TAB
+        Return = 0xD, // KEY_RETURN
+        Pause = 0x13, // KEY_PAUSE
+        Capital = 0x14, // KEY_CAPITAL
+        CapsLock = Capital,
+        Escape = 0x1B, // KEY_ESCAPE
+        Space = 0x20, // KEY_SPACE
+        PageUp = 0x21, // KEY_PAGEUP
+        Prior = PageUp, // KEY_PRIOR
+        PageDown = 0x22, // KEY_PAGEDOWN
+        Next = PageDown, // KEY_NEXT
+        End = 0x23, // KEY_END
+        Home = 0x24, // KEY_HOME
+        Left = 0x25, // KEY_LEFT
+        Up = 0x26, // KEY_UP
+        Right = 0x27, // KEY_RIGHT
+        Down = 0x28, // KEY_DOWN
+        Snapshot = 0x2C, // KEY_SNAPSHOT
+        PrintScreen = Snapshot,
+        SysRq = Snapshot, // KEY_SYSRQ
+        Insert = 0x2D, // KEY_INSERT
+        Delete = 0x2E, // KEY_DELETE
+        D0 = 0x30, // KEY_0
+        D1 = 0x31, // KEY_1
+        D2 = 0x32, // KEY_2
+        D3 = 0x33, // KEY_3
+        D4 = 0x34, // KEY_4
+        D5 = 0x35, // KEY_5
+        D6 = 0x36, // KEY_6
+        D7 = 0x37, // KEY_7
+        D8 = 0x38, // KEY_8
+        D9 = 0x39, // KEY_9
+        A = 0x41, // KEY_A
+        B = 0x42, // KEY_B
+        C = 0x43, // KEY_C
+        D = 0x44, // KEY_D
+        E = 0x45, // KEY_E
+        F = 0x46, // KEY_F
+        G = 0x47, // KEY_G
+        H = 0x48, // KEY_H
+        I = 0x49, // KEY_I
+        J = 0x4A, // KEY_J
+        K = 0x4B, // KEY_K
+        L = 0x4C, // KEY_L
+        M = 0x4D, // KEY_M
+        N = 0x4E, // KEY_N
+        O = 0x4F, // KEY_O
+        P = 0x50, // KEY_P
+        Q = 0x51, // KEY_Q
+        R = 0x52, // KEY_R
+        S = 0x53, // KEY_S
+        T = 0x54, // KEY_T
+        U = 0x55, // KEY_U
+        V = 0x56, // KEY_V
+        W = 0x57, // KEY_W
+        X = 0x58, // KEY_X
+        Y = 0x59, // KEY_Y
+        Z = 0x5A, // KEY_Z
+        LWin = 0x5B, // KEY_LWIN
+        RWin = 0x5C, // KEY_RWIN
+        Apps = 0x5D, // KEY_APPS
+        NumPad0 = 0x60, // KEY_NUMPAD0
+        NumPad1 = 0x61, // KEY_NUMPAD1
+        NumPad2 = 0x62, // KEY_NUMPAD2
+        NumPad3 = 0x63, // KEY_NUMPAD3
+        NumPad4 = 0x64, // KEY_NUMPAD4
+        NumPad5 = 0x65, // KEY_NUMPAD5
+        NumPad6 = 0x66, // KEY_NUMPAD6
+        NumPad7 = 0x67, // KEY_NUMPAD7
+        NumPad8 = 0x68, // KEY_NUMPAD8
+        NumPad9 = 0x69, // KEY_NUMPAD9
+        Multiply = 0x6A, // KEY_MULTIPLY
+        Add = 0x6B, // KEY_ADD
+        Subtract = 0x6D, // KEY_SUBTRACT
+        Decimal = 0x6E, // KEY_DECIMAL
+        Divide = 0x6F, // KEY_DIVIDE
+        F1 = 0x70, // KEY_F1
+        F2 = 0x71, // KEY_F2
+        F3 = 0x72, // KEY_F3
+        F4 = 0x73, // KEY_F4
+        F5 = 0x74, // KEY_F5
+        F6 = 0x75, // KEY_F6
+        F7 = 0x76, // KEY_F7
+        F8 = 0x77, // KEY_F8
+        F9 = 0x78, // KEY_F9
+        F10 = 0x79, // KEY_F10
+        F11 = 0x7A, // KEY_F11
+        F12 = 0x7B, // KEY_F12
+        F13 = 0x7C, // KEY_F13
+        F14 = 0x7D, // KEY_F14
+        F15 = 0x7E, // KEY_F15
+        F16 = 0x7F, // KEY_F16
+        F17 = 0x80, // KEY_F17
+        F18 = 0x81, // KEY_F18
+        F19 = 0x82, // KEY_F19
+        F20 = 0x83, // KEY_F20
+        F21 = 0x84, // KEY_F21
+        F22 = 0x85, // KEY_F22
+        F23 = 0x86, // KEY_F23
+        F24 = 0x87, // KEY_F24
+        NumLock = 0x90, // KEY_NUMLOCK
+        Scroll = 0x91, // KEY_SCROLL
+        NumPadEquals = 0x92, // KEY_NUMPADEQUALS
+        LShift = 0xA0, // KEY_LSHIFT
+        RShift = 0xA1, // KEY_RSHIFT
+        LControl = 0xA2, // KEY_LCONTROL
+        RControl = 0xA3, // KEY_RCONTROL
+        LMenu = 0xA4, // KEY_LMENU
+        RMenu = 0xA5, // KEY_RMENU
+        Semicolon = 0xBA, // KEY_SEMICOLON
+        Oem1 = Semicolon, // KEY_OEM_1
+        Plus = 0xBB, // KEY_PLUS
+        Equals = Plus, // KEY_EQUALS
+        Comma = 0xBC, // KEY_COMMA
+        Minus = 0xBD, // KEY_MINUS
+        Period = 0xBE, // KEY_PERIOD
+        Slash = 0xBF, // KEY_SLASH
+        Oem2 = Slash, // KEY_OEM_2
+        Grave = 0xC0, // KEY_GRAVE
+        Oem3 = Grave, // KEY_OEM_3
+        LBracket = 0xDB, // KEY_LBRACKET
+        Oem4 = LBracket, // KEY_OEM_4
+        Backslash = 0xDC, // KEY_BACKSLASH
+        Oem5 = Backslash, // KEY_OEM_5
+        RBracket = 0xDD, // KEY_RBRACKET
+        Oem6 = RBracket, // KEY_OEM_6
+        Apostrophe = 0xDE, // KEY_APOSTROPHE
+        Oem7 = Apostrophe, // KEY_OEM_7
+        Oem102 = 0xE2, // KEY_OEM_102
+        // KEY_RAGE_EXTRA1 = 0xF0,
+        // KEY_RAGE_EXTRA2 = 0xF1,
+        // KEY_RAGE_EXTRA3 = 0xF2,
+        // KEY_RAGE_EXTRA4 = 0xF4,
+        NumPadEnter = 0xFD, // KEY_NUMPADENTER
+        // KEY_CHATPAD_GREEN_SHIFT = 0xFE,
+        // KEY_CHATPAD_ORANGE_SHIFT = 0xFF,
+
+        MouseLeft = 0x801,
+        MouseRight = 0x802,
+        MouseMiddle = 0x804,
+        MouseExtra1 = 0x808,
+        MouseExtra2 = 0x810,
+        MouseExtra3 = 0x820,
+        MouseExtra4 = 0x840,
+        MouseExtra5 = 0x880,
+    }
+}

--- a/Source/Examples/Showcase/InstructionalButtons.cs
+++ b/Source/Examples/Showcase/InstructionalButtons.cs
@@ -4,6 +4,7 @@
     using RAGENativeUI.Elements;
     using Rage;
     using System.Drawing;
+    using System.Linq;
 
     internal sealed class InstructionalButtons : UIMenu
     {
@@ -83,6 +84,7 @@
             private string buttonText = "A";
             private GameControl buttonControl = GameControl.Context;
             private uint buttonRawId = 0;
+            private InstructionalKey buttonInstructionalKey = InstructionalKey.Unknown;
 
             public ButtonMenu(InstructionalButton button) : base(Plugin.MenuTitle, "INSTRUCTIONAL BUTTONS: " + button.Text.ToUpper())
             {
@@ -123,20 +125,34 @@
                     InstructionalButtons.Update();
                 };
 
-                var type = new UIMenuListScrollerItem<string>("Type", "", new[] { "Text", "Control", "Raw ID" });
+                var instructionalKey = new UIMenuListScrollerItem<InstructionalKey>("Instructional Key", "", ((InstructionalKey[])System.Enum.GetValues(typeof(InstructionalKey))).Distinct())
+                {
+                    Enabled = false,
+                    SelectedItem = buttonInstructionalKey
+                };
+                instructionalKey.IndexChanged += (s, o, n) =>
+                {
+                    buttonInstructionalKey = instructionalKey.SelectedItem;
+                    this.button.Button = instructionalKey.SelectedItem;
+                    InstructionalButtons.Update();
+                };
+
+                var type = new UIMenuListScrollerItem<string>("Type", "", new[] { "Text", "Control", "Raw ID", "Instructional Key" });
                 type.IndexChanged += (s, o, n) =>
                 {
-                    const int TextIdx = 0, ControlIdx = 1, RawIdIdx = 2;
+                    const int TextIdx = 0, ControlIdx = 1, RawIdIdx = 2, InstructionalKeyIdx = 3;
 
                     text.Enabled = n == TextIdx;
                     control.Enabled = n == ControlIdx;
                     rawId.Enabled = n == RawIdIdx;
+                    instructionalKey.Enabled = n == InstructionalKeyIdx;
 
                     this.button.Button = n switch
                     {
                         TextIdx => buttonText,
                         ControlIdx => buttonControl,
                         RawIdIdx => buttonRawId,
+                        InstructionalKeyIdx => buttonInstructionalKey,
                         _ => buttonText
                     };
                     InstructionalButtons.Update();
@@ -164,7 +180,7 @@
                     }
                 };
 
-                AddItems(type, text, control, rawId, remove);
+                AddItems(type, text, control, rawId, instructionalKey, remove);
             }
         }
     }

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -98,6 +98,23 @@ internal static class Plugin
                 InstructionalKey.MouseExtra4,
                 InstructionalKey.MouseExtra5,
             };
+
+            yield return new InstructionalKey[]
+            {
+                InstructionalKey.MouseWheelUp,
+                InstructionalKey.MouseWheelDown,
+                InstructionalKey.MouseWheel,
+            };
+
+            yield return new InstructionalKey[]
+            {
+                InstructionalKey.MouseAxisX,
+                InstructionalKey.MouseAxisXLeft,
+                InstructionalKey.MouseAxisXRight,
+                InstructionalKey.MouseAxisY,
+                InstructionalKey.MouseAxisYUp,
+                InstructionalKey.MouseAxisYDown,
+            };
         }
     }
 }

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -49,7 +49,7 @@ internal static class Plugin
     [ConsoleCommand]
     private static void InstructionalKeysSimpleTest()
     {
-        Game.DisplayHelp($"Press ~{Keys.Space.GetInstructionalId()}~ ~{Keys.MButton.GetInstructionalId()}~ ~{ControllerButtons.A.GetInstructionalId()}~");
+        Game.DisplayHelp($"Press ~{Keys.Space.GetInstructionalId()}~ ~+~ ~{Keys.MButton.GetInstructionalId()}~ ~+~ ~{ControllerButtons.A.GetInstructionalId()}~");
     }
 
     [ConsoleCommand]

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using Rage;
 using RAGENativeUI;
 using RAGENativeUI.PauseMenu;
+using Rage.Attributes;
+using RAGENativeUI.Elements;
 
 internal static class Plugin
 {
@@ -42,5 +44,20 @@ internal static class Plugin
             // process input and draw the visible menus
             Pool.ProcessMenus();
         }
+    }
+
+    [ConsoleCommand]
+    private static void InstructionalKeysTest()
+    {
+        string unknown = InstructionalKey.Unknown.GetId();
+        string oem5 = InstructionalKey.Oem5.GetId();
+        string oem102 = InstructionalKey.Oem102.GetId();
+
+
+        Game.Console.Print(unknown);
+        Game.Console.Print(oem5);
+        Game.Console.Print(oem102);
+
+        Game.DisplayHelp($"a ~{unknown}~ a ~{oem5}~ a ~{oem102}~ a");
     }
 }

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -131,6 +131,24 @@ internal static class Plugin
                 InstructionalKey.ControllerAxisRXLeft,
                 InstructionalKey.ControllerAxisRXRight,
             };
+
+            yield return new InstructionalKey[]
+            {
+                InstructionalKey.ControllerDPadAll,
+                InstructionalKey.ControllerDPadUpDown,
+                InstructionalKey.ControllerDPadLeftRight,
+                InstructionalKey.ControllerLStickRotate,
+                InstructionalKey.ControllerRStickRotate,
+                InstructionalKey.SymbolBusySpinner,
+                InstructionalKey.SymbolPlus,
+                InstructionalKey.SymbolArrowUp,
+                InstructionalKey.SymbolArrowDown,
+                InstructionalKey.SymbolArrowLeft,
+                InstructionalKey.SymbolArrowRight,
+                InstructionalKey.SymbolArrowUpDown,
+                InstructionalKey.SymbolArrowLeftRight,
+                InstructionalKey.SymbolArrowAll,
+            };
         }
     }
 }

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Windows.Forms;
 using System.Linq;
+using System.Collections.Generic;
 using Rage;
 using RAGENativeUI;
 using RAGENativeUI.PauseMenu;
@@ -45,19 +46,58 @@ internal static class Plugin
             Pool.ProcessMenus();
         }
     }
+    [ConsoleCommand]
+    private static void InstructionalKeysSimpleTest()
+    {
+        Game.DisplayHelp($"Press ~{Keys.Space.GetInstructionalId()}~ ~{Keys.MButton.GetInstructionalId()}~ ~{ControllerButtons.A.GetInstructionalId()}~");
+    }
 
     [ConsoleCommand]
     private static void InstructionalKeysTest()
     {
-        string unknown = InstructionalKey.Unknown.GetId();
-        string oem5 = InstructionalKey.Oem5.GetId();
-        string oem102 = InstructionalKey.Oem102.GetId();
+        GameFiber.StartNew(() =>
+        {
+            foreach (var keys in GetKeys())
+            {
+                string str = string.Join("~n~", keys.Select(k => $"~{k.GetId()}~"));
+                Game.DisplayHelp(str);
+                GameFiber.Sleep(5000);
+            }
+        });
 
+        static IEnumerable<InstructionalKey[]> GetKeys()
+        {
+            yield return new InstructionalKey[]
+            {
+                ControllerButtons.DPadUp.GetInstructionalKey(),
+                ControllerButtons.DPadDown.GetInstructionalKey(),
+                ControllerButtons.DPadLeft.GetInstructionalKey(),
+                ControllerButtons.DPadRight.GetInstructionalKey(),
+                ControllerButtons.Start.GetInstructionalKey(),
+                ControllerButtons.Back.GetInstructionalKey(),
+                ControllerButtons.LeftThumb.GetInstructionalKey(),
+                ControllerButtons.RightThumb.GetInstructionalKey(),
+                ControllerButtons.LeftShoulder.GetInstructionalKey(),
+                ControllerButtons.RightShoulder.GetInstructionalKey(),
+                InstructionalKey.ControllerLTrigger,
+                InstructionalKey.ControllerRTrigger,
+                ControllerButtons.A.GetInstructionalKey(),
+                ControllerButtons.B.GetInstructionalKey(),
+                ControllerButtons.X.GetInstructionalKey(),
+                ControllerButtons.Y.GetInstructionalKey(),
+            };
 
-        Game.Console.Print(unknown);
-        Game.Console.Print(oem5);
-        Game.Console.Print(oem102);
-
-        Game.DisplayHelp($"a ~{unknown}~ a ~{oem5}~ a ~{oem102}~ a");
+            yield return new InstructionalKey[]
+            {
+                InstructionalKey.MouseLeft,
+                InstructionalKey.MouseRight,
+                InstructionalKey.MouseMiddle,
+                InstructionalKey.MouseExtra1,
+                InstructionalKey.MouseExtra2,
+                InstructionalKey.MouseExtra3,
+                InstructionalKey.MouseExtra4,
+                InstructionalKey.MouseExtra5,
+            };
+        }
     }
 }

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -115,6 +115,22 @@ internal static class Plugin
                 InstructionalKey.MouseAxisYUp,
                 InstructionalKey.MouseAxisYDown,
             };
+
+            yield return new InstructionalKey[]
+            {
+                InstructionalKey.ControllerAxisLX,
+                InstructionalKey.ControllerAxisLY,
+                InstructionalKey.ControllerAxisLYUp,
+                InstructionalKey.ControllerAxisLYDown,
+                InstructionalKey.ControllerAxisLXLeft,
+                InstructionalKey.ControllerAxisLXRight,
+                InstructionalKey.ControllerAxisRX,
+                InstructionalKey.ControllerAxisRY,
+                InstructionalKey.ControllerAxisRYUp,
+                InstructionalKey.ControllerAxisRYDown,
+                InstructionalKey.ControllerAxisRXLeft,
+                InstructionalKey.ControllerAxisRXRight,
+            };
         }
     }
 }

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -6,7 +6,6 @@ using Rage;
 using RAGENativeUI;
 using RAGENativeUI.PauseMenu;
 using Rage.Attributes;
-using RAGENativeUI.Elements;
 
 internal static class Plugin
 {

--- a/Source/Examples/Showcase/Plugin.cs
+++ b/Source/Examples/Showcase/Plugin.cs
@@ -49,7 +49,7 @@ internal static class Plugin
     [ConsoleCommand]
     private static void InstructionalKeysSimpleTest()
     {
-        Game.DisplayHelp($"Press ~{Keys.Space.GetInstructionalId()}~ ~+~ ~{Keys.MButton.GetInstructionalId()}~ ~+~ ~{ControllerButtons.A.GetInstructionalId()}~");
+        Game.DisplayHelp($"Press ~{Keys.Space.GetInstructionalId()}~ ~+~ ~{Keys.MButton.GetInstructionalId()}~ ~+~ ~{ControllerButtons.A.GetInstructionalId()}~ ~+~ ~{Keys.A.GetInstructionalId()}~ ~+~ ~{Keys.OemCloseBrackets.GetInstructionalId()}~");
     }
 
     [ConsoleCommand]

--- a/Source/InstructionalKey.cs
+++ b/Source/InstructionalKey.cs
@@ -1,4 +1,4 @@
-﻿namespace RAGENativeUI.Elements
+﻿namespace RAGENativeUI
 {
     using System.Text;
     using System.Windows.Forms;

--- a/Source/Internals/Memory.cs
+++ b/Source/Internals/Memory.cs
@@ -11,7 +11,7 @@
 
     internal static unsafe class Memory
     {
-        public const int MaxMemoryAddresses = 11;
+        public const int MaxMemoryAddresses = 13;
         public const int MaxInts = 4;
 
         public static readonly IntPtr Screen_GetActualWidth, Screen_GetActualHeight;
@@ -24,6 +24,8 @@
         public static readonly IntPtr Native_DisableControlAction;
         public static readonly IntPtr Native_DrawSprite;
         public static readonly IntPtr Native_DrawRect;
+        public static readonly IntPtr CTextFormat_GetInputSourceIcons;
+        public static readonly IntPtr CTextFormat_GetIconListFormatString;
         public static readonly int TimershudSharedGlobalId = -1;
         public static readonly int TimershudSharedTimerbarsTotalHeightOffset = -1;
         public static readonly int TimerbarsPrevTotalHeightGlobalId = -1;
@@ -107,6 +109,16 @@
                 }
                 return addr;
             });
+
+            {
+                IntPtr addr = FindAddress(() => Game.FindPattern("E8 ?? ?? ?? ?? 83 7C 24 ?? ?? 7E 3A 48 8D 4C 24"));
+                if (addr != IntPtr.Zero)
+                {
+                    CTextFormat_GetInputSourceIcons = addr + *(int*)(addr + 1) + 5;
+                    addr += 0x27;
+                    CTextFormat_GetIconListFormatString = addr + *(int*)(addr + 1) + 5;
+                }
+            }
 
             if (Shared.MemoryInts[0] == 0 || Shared.MemoryInts[1] == 0 || Shared.MemoryInts[2] == 0)
             {
@@ -419,5 +431,43 @@
         [FieldOffset(0x0)] public IntPtr Val;
         [FieldOffset(0x0)] public float AsFloat;
         [FieldOffset(0x0)] public int AsInt;
+    }
+
+    internal static unsafe class CTextFormat
+    {
+        public static readonly bool Available = Memory.CTextFormat_GetInputSourceIcons != IntPtr.Zero &&
+                                                Memory.CTextFormat_GetIconListFormatString != IntPtr.Zero;
+
+        public static void GetInputSourceIcons(uint mapperSource, uint mapperParameter, ref atFixedArray_sIconData_4 icons)
+            => getInputSourceIcons(mapperSource, mapperParameter, ref icons);
+
+        public static void GetIconListFormatString(ref atFixedArray_sIconData_4 icons, byte* buffer, uint bufferSize)
+            => getIconListFormatString(ref icons, buffer, bufferSize, IntPtr.Zero);
+
+        private delegate void GetInputSourceIcons_Delegate(uint mapperSource, uint mapperParameter, ref atFixedArray_sIconData_4 icons);
+        private delegate void GetIconListFormatString_Delegate(ref atFixedArray_sIconData_4 icons, byte* buffer, uint bufferSize, /* sIconParams* */IntPtr iconParamsUnused);
+
+        private static readonly GetInputSourceIcons_Delegate getInputSourceIcons =
+            Available ? Marshal.GetDelegateForFunctionPointer<GetInputSourceIcons_Delegate>(Memory.CTextFormat_GetInputSourceIcons) : null;
+
+        private static readonly GetIconListFormatString_Delegate getIconListFormatString =
+            Available ? Marshal.GetDelegateForFunctionPointer<GetIconListFormatString_Delegate>(Memory.CTextFormat_GetIconListFormatString) : null;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 0x8)]
+    internal struct sIconData
+    {
+        public int rawIdOrIndex;
+        public int type;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 0x24)]
+    internal struct atFixedArray_sIconData_4
+    {
+        public sIconData Item0;
+        public sIconData Item1;
+        public sIconData Item2;
+        public sIconData Item3;
+        public int Count;
     }
 }

--- a/Source/Internals/Memory.cs
+++ b/Source/Internals/Memory.cs
@@ -11,7 +11,7 @@
 
     internal static unsafe class Memory
     {
-        public const int MaxMemoryAddresses = 13;
+        public const int MaxMemoryAddresses = 15;
         public const int MaxInts = 4;
 
         public static readonly IntPtr Screen_GetActualWidth, Screen_GetActualHeight;
@@ -26,6 +26,7 @@
         public static readonly IntPtr Native_DrawRect;
         public static readonly IntPtr CTextFormat_GetInputSourceIcons;
         public static readonly IntPtr CTextFormat_GetIconListFormatString;
+        public static readonly IntPtr CControlMgr_sm_MappingMgr_KeyboardLayout;
         public static readonly int TimershudSharedGlobalId = -1;
         public static readonly int TimershudSharedTimerbarsTotalHeightOffset = -1;
         public static readonly int TimerbarsPrevTotalHeightGlobalId = -1;
@@ -119,6 +120,16 @@
                     CTextFormat_GetIconListFormatString = addr + *(int*)(addr + 1) + 5;
                 }
             }
+
+            CControlMgr_sm_MappingMgr_KeyboardLayout = FindAddress(() =>
+            {
+                IntPtr addr = Game.FindPattern("48 8D 05 ?? ?? ?? ?? 41 B8 ?? ?? ?? ?? 48 C1 E3 04 48 03 D8 44 39 03");
+                if (addr != IntPtr.Zero)
+                {
+                    addr += *(int*)(addr + 3) + 7;
+                }
+                return addr;
+            });
 
             if (Shared.MemoryInts[0] == 0 || Shared.MemoryInts[1] == 0 || Shared.MemoryInts[2] == 0)
             {
@@ -469,5 +480,19 @@
         public sIconData Item2;
         public sIconData Item3;
         public int Count;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    internal unsafe struct CControlKeyboardLayoutKey
+    {
+        public const int MaxTextLength = 10;
+
+        public int Icon;
+        public fixed byte Text[MaxTextLength];
+
+
+        public static readonly bool Available = Memory.CControlMgr_sm_MappingMgr_KeyboardLayout != IntPtr.Zero;
+        public static CControlKeyboardLayoutKey* KeyboardLayout = (CControlKeyboardLayoutKey*)Memory.CControlMgr_sm_MappingMgr_KeyboardLayout;
+        public const int KeyboardLayoutSize = 255;
     }
 }

--- a/Source/Internals/ModuleInitializer.cs
+++ b/Source/Internals/ModuleInitializer.cs
@@ -34,6 +34,9 @@
             Game.LogTrivialDebug("[RAGENativeUI] > Registering debug commands");
             Game.AddConsoleCommands(new[] { typeof(DebugCommands) });
 #endif
+
+            Game.LogTrivialDebug("[RAGENativeUI] > Hooking token parser");
+            TokenParserHook.Init();
         }
     }
 }

--- a/Source/Internals/Shared.cs
+++ b/Source/Internals/Shared.cs
@@ -32,7 +32,7 @@
         public static long* MemoryAddresses => data->MemoryAddresses;
         public static int* MemoryInts => data->MemoryInts;
 
-        public static ref uint TokenParserHookRefs => ref data->TokenParserHookRefs;
+        public static ref TokenParserHookData TokenParserHookData => ref data->TokenParserHookData;
 
         static Shared()
         {
@@ -90,7 +90,7 @@
             public uint NumberOfVisiblePauseMenus;
             public fixed long MemoryAddresses[Memory.MaxMemoryAddresses];
             public fixed int MemoryInts[Memory.MaxInts];
-            public uint TokenParserHookRefs;
+            public TokenParserHookData TokenParserHookData;
         }
     }
 }

--- a/Source/Internals/Shared.cs
+++ b/Source/Internals/Shared.cs
@@ -32,6 +32,8 @@
         public static long* MemoryAddresses => data->MemoryAddresses;
         public static int* MemoryInts => data->MemoryInts;
 
+        public static ref uint TokenParserHookRefs => ref data->TokenParserHookRefs;
+
         static Shared()
         {
             Game.LogTrivialDebug($"[RAGENativeUI::Shared] Init from '{System.AppDomain.CurrentDomain.FriendlyName}'");
@@ -54,6 +56,7 @@
                 // in case there is any visible menus when unloading the plugin
                 NumberOfVisibleMenus -= UIMenu.NumberOfVisibleMenus;
                 NumberOfVisiblePauseMenus -= TabView.NumberOfVisiblePauseMenus;
+                TokenParserHook.Shutdown();
             }
 
             // dispose mapped file
@@ -87,6 +90,7 @@
             public uint NumberOfVisiblePauseMenus;
             public fixed long MemoryAddresses[Memory.MaxMemoryAddresses];
             public fixed int MemoryInts[Memory.MaxInts];
+            public uint TokenParserHookRefs;
         }
     }
 }

--- a/Source/Internals/TokenParserHook.cs
+++ b/Source/Internals/TokenParserHook.cs
@@ -234,6 +234,16 @@
             int tokenLength = StrLen(token);
             Log($"TokenParser({Encoding.UTF8.GetString(token, tokenLength)}, {((IntPtr)Unsafe.AsPointer(ref icon)).ToString("X16")})");
 
+            if (tokenLength == 1 && token[0] == '+')
+            {
+                // alias for 'b_998' (plus symbol)
+                icon.iconTypeList[0] = (byte)'b';
+                icon.iconList[0] = 998;
+                icon.useIdAsMovieName = 0;
+                Log($" > success: '+' alias");
+                return true;
+            }
+
             if (tokenLength <= 2)
             {
                 Log($" > failed: token too short");

--- a/Source/Internals/TokenParserHook.cs
+++ b/Source/Internals/TokenParserHook.cs
@@ -263,7 +263,7 @@
                     case 0: // prefix
                         if (c != 't' && c != 'T' && c != 'b')
                         {
-                            Log($" > failed: expected 't', 'T' or 'b', got '{c}'");
+                            Log($" > failed: expected 't', 'T' or 'b', got '{(char)c}'");
                             return false;
                         }
 
@@ -273,7 +273,7 @@
                     case 1: // underscore separator
                         if (c != '_')
                         {
-                            Log($" > failed: expected underscore '_', got '{c}'");
+                            Log($" > failed: expected underscore '_', got '{(char)c}'");
                             return false;
                         }
                         state = 2;
@@ -329,7 +329,7 @@
 
                             if (!found)
                             {
-                                Log($" > failed: no matching key in keyboard layout for '{c}'");
+                                Log($" > failed: no matching key in keyboard layout for '{(char)c}'");
                                 return false;
                             }
                         }
@@ -338,7 +338,7 @@
                     case 3: // group separator
                         if (c != Separator)
                         {
-                            Log($" > failed: expected group separator '{Separator}', got '{c}'");
+                            Log($" > failed: expected group separator '{Separator}', got '{(char)c}'");
                             return false;
                         }
                         iconIndex++;

--- a/Source/Internals/TokenParserHook.cs
+++ b/Source/Internals/TokenParserHook.cs
@@ -1,0 +1,410 @@
+﻿namespace RAGENativeUI.Internals
+{
+    using System;
+    using System.Diagnostics;
+    using System.Runtime.InteropServices;
+
+    using Rage;
+
+    using RAGENativeUI.IL;
+
+    internal static unsafe class TokenParserHook
+    {
+        private static IntPtr hookAddr;
+        private static byte[] origCode;
+        private static IntPtr failedJumpAddr;
+        private static IntPtr successJumpAddr;
+        private static IntPtr stubAddr;
+
+        private static ParseTokenDelegate tokenParser;
+        private static IntPtr tokenParserAddr;
+
+        private static CControlKeyboardLayoutKey* keyboardLayout;
+        private const int KeyboardLayoutSize = 255;
+
+        [Conditional("DEBUG")]
+        private static void Log(string str) => Game.LogTrivialDebug($"[RAGENativeUI::{nameof(TokenParserHook)}] {str}");
+
+        public static void Init()
+        {
+            Shared.TokenParserHookRefs++;
+            Log($"Init (refs: {Shared.TokenParserHookRefs})");
+            if (Shared.TokenParserHookRefs > 1)
+            {
+                return;
+            }
+
+            IntPtr addr = Game.FindPattern("E8 ?? ?? ?? ?? 84 C0 0F 84 ?? ?? ?? ?? F3 0F 10 45 ?? 0F 2F 45 98");
+            if (addr == IntPtr.Zero)
+            {
+                Log($"addr pattern not found");
+                return;
+            }
+
+            hookAddr = addr + 5; // skip call
+            failedJumpAddr = hookAddr + *(int*)(hookAddr + 4) + 8;
+            successJumpAddr = hookAddr + 8;
+
+            IntPtr keyboardLayoutPtr = Game.FindPattern("48 8D 05 ?? ?? ?? ?? 41 B8 ?? ?? ?? ?? 48 C1 E3 04 48 03 D8 44 39 03");
+            if (keyboardLayoutPtr == IntPtr.Zero)
+            {
+                Log($"keyboardLayoutPtr pattern not found");
+                return;
+            }
+            keyboardLayout = (CControlKeyboardLayoutKey*)(keyboardLayoutPtr + *(int*)(keyboardLayoutPtr + 3) + 7);
+
+            stubAddr = AllocateStub();
+
+            // TODO: this will crash when the plugin that owns this delegate gets unloaded but there is still other RNUI instances
+            tokenParser = TokenParser;
+            tokenParserAddr = Marshal.GetFunctionPointerForDelegate(tokenParser);
+
+            Log($"hookAddr = {hookAddr.ToString("X16")}");
+            Log($"failedJumpAddr = {failedJumpAddr.ToString("X16")}");
+            Log($"successJumpAddr = {successJumpAddr.ToString("X16")}");
+            Log($"stubAddr = {stubAddr.ToString("X16")}");
+            Log($"tokenParserAddr = {tokenParserAddr.ToString("X16")}");
+            Log($"keyboardLayout = {((IntPtr)keyboardLayout).ToString("X16")}");
+
+            if (stubAddr == IntPtr.Zero)
+            {
+                Log($"Stub allocation failed");
+                return;
+            }
+
+            // prepare our stub
+            Marshal.Copy(stubCode, 0, stubAddr, stubCode.Length);
+            SetJnz(stubAddr + 2, successJumpAddr);
+            SetMov(stubAddr + (stubCode.Length - 5 - 6 - 2 - 2 - 10), tokenParserAddr);
+            SetJz(stubAddr + (stubCode.Length - 5 - 6), failedJumpAddr);
+            Jmp(stubAddr + (stubCode.Length - 5), successJumpAddr);
+
+            // prepare the hook in the original function
+            origCode = Nop(hookAddr, 8);
+            Jmp(hookAddr, stubAddr);
+        }
+
+        public static void Shutdown()
+        {
+            Shared.TokenParserHookRefs--;
+            Log($"Shutdown (refs: {Shared.TokenParserHookRefs})");
+            if (Shared.TokenParserHookRefs != 0)
+            {
+                return;
+            }
+
+            if (stubAddr == IntPtr.Zero)
+            {
+                return;
+            }
+
+            Marshal.Copy(origCode, 0, hookAddr, origCode.Length);
+
+            VirtualFree(stubAddr, 0, MEM_RELEASE);
+        }
+
+        private static void SetCall(IntPtr callInst, IntPtr funcAddr)
+        {
+            long offset = funcAddr.ToInt64() - (callInst + 5).ToInt64();
+
+            if (offset < int.MinValue || offset > int.MaxValue)
+            {
+                Log($"{nameof(SetCall)}: offset does not fit in int32 => {offset.ToString("X16")}");
+                return;
+            }
+
+            *(int*)(callInst + 1) = (int)offset;
+        }
+
+        private static void SetJnz(IntPtr jnzInst, IntPtr jumpAddr) => SetJz(jnzInst, jumpAddr);
+        private static void SetJz(IntPtr jzInst, IntPtr jumpAddr)
+        {
+            long offset = jumpAddr.ToInt64() - (jzInst + 6).ToInt64();
+
+            if (offset < int.MinValue || offset > int.MaxValue)
+            {
+                Log($"{nameof(SetJz)}: offset does not fit in int32 => {offset.ToString("X16")}");
+                return;
+            }
+
+            *(int*)(jzInst + 2) = (int)offset;
+        }
+
+        // sets value of 'mov rax, value'
+        private static void SetMov(IntPtr movInst, IntPtr value)
+        {
+            *(IntPtr*)(movInst + 2) = value;
+        }
+
+        private static byte[] Nop(IntPtr addr, int size)
+        {
+            byte[] orig = new byte[size];
+            for (int i = 0; i< size; i++)
+            {
+                byte* b = (byte*)(addr + i);
+                orig[i] = *b;
+                *b = 0x90;
+            }
+            return orig;
+        }
+
+        private static void Jmp(IntPtr addr, IntPtr jumpAddr)
+        {
+            long offset = jumpAddr.ToInt64() - (addr + 5).ToInt64();
+
+            if (offset < int.MinValue || offset > int.MaxValue)
+            {
+                Log($"{nameof(Jmp)}: offset does not fit in int32 => {offset.ToString("X16")}");
+                return;
+            }
+
+            *(byte*)(addr + 0) = 0xE9;
+            *(int*)(addr + 1) = (int)offset;
+        }
+
+        private static IntPtr AllocateStub()
+        {
+            SYSTEM_INFO info = default;
+            GetSystemInfo(ref info);
+
+            const long MaxMemoryRange = 0x40000000;
+            const int PageSize = 0x1000;
+
+            if (stubCode.Length > PageSize)
+            {
+                Log($"AllocateStub: stubCode length greater than allocated page size => {stubCode.Length.ToString("X8")}");
+                return IntPtr.Zero;
+            }
+
+            long addr = Process.GetCurrentProcess().MainModule.BaseAddress.ToInt64();
+            long minAddr = addr - MaxMemoryRange;
+
+            Log($"AllocateStub: stubSearch StartAddr = {addr.ToString("X16")}");
+            Log($"AllocateStub: stubSearch MinAddr = {minAddr.ToString("X16")}");
+            Log($"AllocateStub: stubSearch AllocGranularity = {info.dwAllocationGranularity.ToString("X8")}");
+
+            addr -= addr % info.dwAllocationGranularity;
+            addr -= info.dwAllocationGranularity;
+            while (addr >= minAddr)
+            {
+                MEMORY_BASIC_INFORMATION memInfo = default;
+                if (VirtualQuery((IntPtr)addr, ref memInfo, sizeof(MEMORY_BASIC_INFORMATION)) == 0)
+                {
+                    break;
+                }
+
+                if (memInfo.State == MEM_FREE)
+                {
+                    Log($"AllocateStub: stubSearch Found free memory = {addr.ToString("X16")}");
+                    IntPtr allocAddr = VirtualAlloc((IntPtr)addr, PageSize, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+                    
+                    if (allocAddr != IntPtr.Zero)
+                    {
+                        return allocAddr;
+                    }
+                }
+
+                if (memInfo.AllocationBase.ToUInt64() < info.dwAllocationGranularity)
+                {
+                    break;
+                }
+
+                addr = (long)(memInfo.AllocationBase.ToUInt64() - info.dwAllocationGranularity);
+            }
+
+            return IntPtr.Zero;
+        }
+
+        static readonly byte[] stubCode = new byte[]
+        {
+            0x84, 0xC0,                                                     // test al, al
+            0x0F, 0x85, 0x00, 0x00, 0x00, 0x00,                             // jnz  success
+            0x48, 0x8D, 0x95, 0x90, 0x01, 0x00, 0x00,                       // lea  rdx,[rbp + 0x190] ; rdx = sIcon*
+            0x48, 0x8D, 0x8D, 0x30, 0x03, 0x00, 0x00,                       // lea  rcx,[rbp + 0x330] ; rcx = const char* token
+            0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,     // mov  rax, TokenParser
+            0xFF, 0xD0,                                                     // call rax
+            0x84, 0xC0,                                                     // test al, al
+            0x0F, 0x84, 0x00, 0x00, 0x00, 0x00,                             // jz   failed
+            0xE9, 0x00, 0x00, 0x00, 0x00,                                   // jmp  success
+        };
+
+        private static bool TokenParser(string token, ref sIcon icon)
+        {
+            Log($"TokenParser({token}, {((IntPtr)Unsafe.AsPointer(ref icon)).ToString("X16")})");
+
+            if (token.Length <= 2)
+            {
+                Log($" > failed: token too short");
+                return false;
+            }
+
+            const char Separator = '%';
+
+            int iconIndex = 0;
+            int state = 0;
+            for (int i = 0; i < token.Length; i++)
+            {
+                char c = token[i];
+
+                switch (state)
+                {
+                    case 0: // prefix
+                        if (c != 't' && c != 'T' && c != 'b')
+                        {
+                            Log($" > failed: expected underscore 't', 'T' or 'b', got '{c}'");
+                            return false;
+                        }
+
+                        icon.iconTypeList[iconIndex] = (byte)c;
+                        state = 1;
+                        break;
+                    case 1: // underscore separator
+                        if (c != '_')
+                        {
+                            Log($" > failed: expected underscore '_', got '{c}'");
+                            return false;
+                        }
+                        state = 2;
+                        break;
+                    case 2: // button letter or icon
+                        if (icon.iconTypeList[iconIndex] == 'b')
+                        {
+                            // parse the number
+                            int end = token.IndexOf(Separator, i);
+                            end = end == -1 ? token.Length : end;
+                            var numStr = token.Substring(i, end - i);
+                            if (!uint.TryParse(numStr, out var num))
+                            {
+                                Log($" > failed: invalid uint '{numStr}'");
+                                return false;
+                            }
+
+                            i = end - 1;
+                            icon.iconList[iconIndex] = num;
+                        }
+                        else
+                        {
+                            //icon.iconList[iconIndex] = (byte)c;
+
+                            byte b = (byte)c;
+                            bool found = false;
+                            for (int key = 0; key < KeyboardLayoutSize; key++)
+                            {
+                                if (keyboardLayout[key].Icon <= 1 && keyboardLayout[key].Text[0] == b)
+                                {
+                                    icon.iconList[iconIndex] = (uint)key;
+                                    found = true;
+                                    break;
+                                }
+                            }
+
+                            if (!found)
+                            {
+                                Log($" > failed: no matching key in keyboard layout for '{c}'");
+                                return false;
+                            }
+                        }
+                        state = 3;
+                        break;
+                    case 3: // group separator
+                        if (c != Separator)
+                        {
+                            Log($" > failed: expected group separator '{Separator}', got '{c}'");
+                            return false;
+                        }
+                        iconIndex++;
+                        if (iconIndex >= sIcon.MaxIcons)
+                        {
+                            Log($" > failed: too many icons");
+                            return false;
+                        }
+                        state = 0;
+                        break;
+                }
+            }
+
+            Log($" > success");
+            icon.useIdAsMovieName = 0;
+            return true;
+        }
+
+        [return: MarshalAs(UnmanagedType.I1)]
+        private delegate bool ParseTokenDelegate([MarshalAs(UnmanagedType.LPStr)] string token, ref sIcon icon);
+
+        [StructLayout(LayoutKind.Sequential, Size = 0x68)]
+        private struct sIcon
+        {
+            public const int MaxIcons = 4;
+
+            public fixed byte id[64];
+            public fixed uint iconList[MaxIcons];
+            public fixed byte iconTypeList[MaxIcons];
+            public int field_54;
+            public int field_58;
+            public int field_5C;
+            public int field_60;
+            public byte useIdAsMovieName;
+            public byte field_65;
+            public byte field_66;
+            public byte field_67;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+        private struct CControlKeyboardLayoutKey
+        {
+            public int Icon;
+            public fixed byte Text[10];
+        }
+
+
+
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        static extern IntPtr VirtualAlloc(IntPtr lpAddress, int dwSize, uint flAllocationType, uint flProtect);
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        static extern bool VirtualFree(IntPtr lpAddress, int dwSize, uint dwFreeType);
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        static extern int VirtualQuery(IntPtr lpAddress, ref MEMORY_BASIC_INFORMATION lpBuffer, int dwLength);
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+
+        const uint MEM_COMMIT = 0x1000, MEM_RESERVE = 0x2000;
+        const uint MEM_RELEASE = 0x4000;
+        const uint PAGE_EXECUTE_READWRITE = 0x40;
+        const uint MEM_FREE = 0x00010000;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MEMORY_BASIC_INFORMATION
+        {
+            public UIntPtr BaseAddress;
+            public UIntPtr AllocationBase;
+            public uint AllocationProtect;
+            public IntPtr RegionSize;
+            public uint State;
+            public uint Protect;
+            public uint Type;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SYSTEM_INFO
+        {
+            internal PROCESSOR_INFO_UNION p;
+            public uint dwPageSize;
+            public IntPtr lpMinimumApplicationAddress;
+            public IntPtr lpMaximumApplicationAddress;
+            public UIntPtr dwActiveProcessorMask;
+            public uint dwNumberOfProcessors;
+            public uint dwProcessorType;
+            public uint dwAllocationGranularity;
+            public ushort wProcessorLevel;
+            public ushort wProcessorRevision;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct PROCESSOR_INFO_UNION
+        {
+            [FieldOffset(0)] internal uint dwOemId;
+            [FieldOffset(0)] internal ushort wProcessorArchitecture;
+            [FieldOffset(2)] internal ushort wReserved;
+        }
+    }
+}

--- a/Source/RAGENativeUI.csproj
+++ b/Source/RAGENativeUI.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Common.cs" />
     <Compile Include="Elements\BigMessage.cs" />
     <Compile Include="Elements\Container.cs" />
+    <Compile Include="Elements\InstructionalKey.cs" />
     <Compile Include="Elements\MenuItems\UIMenuListScrollerItem.cs" />
     <Compile Include="Elements\MissionPassedScreen.cs" />
     <Compile Include="Elements\Rectangle.cs" />

--- a/Source/RAGENativeUI.csproj
+++ b/Source/RAGENativeUI.csproj
@@ -60,7 +60,7 @@
     <Compile Include="Common.cs" />
     <Compile Include="Elements\BigMessage.cs" />
     <Compile Include="Elements\Container.cs" />
-    <Compile Include="Elements\InstructionalKey.cs" />
+    <Compile Include="InstructionalKey.cs" />
     <Compile Include="Elements\MenuItems\UIMenuListScrollerItem.cs" />
     <Compile Include="Elements\MissionPassedScreen.cs" />
     <Compile Include="Elements\Rectangle.cs" />

--- a/Source/RAGENativeUI.csproj
+++ b/Source/RAGENativeUI.csproj
@@ -80,6 +80,7 @@
     <Compile Include="HudColor.cs" />
     <Compile Include="Internals\atArray.cs" />
     <Compile Include="Internals\DebugCommands.cs" />
+    <Compile Include="Internals\TokenParserHook.cs" />
     <Compile Include="Internals\Memory.cs" />
     <Compile Include="Internals\ModuleInitializer.cs" />
     <Compile Include="Internals\Shared.cs" />


### PR DESCRIPTION
Add support for parsing `~` tokens for arbitrary key icons in help text (and other scaleforms where `SET_FORMATTED_TEXT_WITH_ICONS` is used).
```csharp
Game.DisplayHelp($"Press ~{Keys.LControlKey.GetInstructionalId()}~ ~+~ ~{Keys.E.GetInstructionalId()}~");
```
![Instructional Keys Example](https://user-images.githubusercontent.com/12873137/89669938-9efee400-d8e0-11ea-9889-44b7d327856a.png)

The token format is similar to the strings returned by `GET_CONTROL_INSTRUCTIONAL_BUTTON` and `GET_CONTROL_GROUP_INSTRUCTIONAL_BUTTON`. Supported tokens:
- `t_[char]`/`T_[char]`: char must match one of the keys `Text` in the current keyboard layout (example: `t_A`)
- `b_[id]`: special keys/icons (example: `b_20`)
- Groups of `t_`/`T_`/`b_` tokens separated by `%`  (example: `t_A%b_20`)
- `+`: alias for `b_998` (plus symbol)

Added `InstructionalKey` enum containing values for keys, mouse buttons, controller buttons and other icons, with `GetId()` extension method that returns the correct token.

Added `GetInstructionalId()` and `GetInstructionalKey()` extensions methods for `System.Windows.Forms.Keys` and `Rage.ControllerButtons` enums, to convert them to the correct string token or `InstructionalKey` value.

Added a constructor to `InstructionalButtonId` that takes a `InstructionalKey`.