### PR TITLE
(#109) Use natives instead of WinForms to change the cursor position

### DIFF
--- a/Source/Natives.cs
+++ b/Source/Natives.cs
@@ -160,6 +160,7 @@
 
         public static void SetMouseCursorActiveThisFrame() => Natives.xAAE7CE1D63167423();
         public static void SetMouseCursorSprite(int spriteId) => Natives.x8DB8CFFD58B62552(spriteId);
+        public static void SetMouseCursorLocation(float x, float y) => Natives.xFC695459D4D0E219(x, y);
 
         public static float GetGameplayCamRelativeHeading() => Natives.GetGameplayCamRelativeHeading<float>();
         public static void SetGameplayCamRelativeHeading(float heading) => Natives.SetGameplayCamRelativeHeading(heading);

--- a/Source/UIMenu.cs
+++ b/Source/UIMenu.cs
@@ -204,6 +204,10 @@ namespace RAGENativeUI
         public bool AllowCameraMovement = false;
         public bool ScaleWithSafezone = true;
 
+        // Whether the value of ResetCursorOnOpen should be respected,
+        // set to true while opening the parent menu to avoid resetting the cursor while navigating the menus
+        private bool IgnoreResetCursorOnOpen { get; set; }
+
         //Events
 
         /// <summary>
@@ -1209,17 +1213,16 @@ namespace RAGENativeUI
         /// <summary>
         /// Closes this menu.
         /// </summary>
-        /// <param name="openParentMenu">If <c>true</c> and <see cref="ParentMenu"/> is not <c>null</c>, the parent menu is open after closing this menu.</param>
+        /// <param name="openParentMenu">If <c>true</c> and <see cref="ParentMenu"/> is not <c>null</c>, the parent menu is opened after closing this menu.</param>
         public void Close(bool openParentMenu = true)
         {
             Visible = false;
             if (openParentMenu && ParentMenu != null)
             {
-                var tmp = Cursor.Position;
+                ParentMenu.IgnoreResetCursorOnOpen = true;
                 ParentMenu.Visible = true;
+                ParentMenu.IgnoreResetCursorOnOpen = false;
                 MenuChangeEv(ParentMenu, false);
-                if (ResetCursorOnOpen)
-                    Cursor.Position = tmp;
             }
             MenuCloseEv();
         }
@@ -1668,19 +1671,16 @@ namespace RAGENativeUI
                     }
 
                     InstructionalButtons.Update();
-                    if (ParentMenu != null || !value)
+                    if (ParentMenu != null || !visible)
                     {
                         return;
                     }
 
-                    if (!ResetCursorOnOpen)
+                    if (ResetCursorOnOpen && !IgnoreResetCursorOnOpen)
                     {
-                        return;
+                        N.SetMouseCursorLocation(0.5f, 0.5f);
+                        N.SetMouseCursorSprite(1);
                     }
-
-                    Cursor.Position = new Point(System.Windows.Forms.Screen.PrimaryScreen.Bounds.Width / 2,
-                                                System.Windows.Forms.Screen.PrimaryScreen.Bounds.Height / 2);
-                    N.SetMouseCursorSprite(1);
                 }
             }
         }


### PR DESCRIPTION
Fixes unexpected behaviour in multiple displays setups, since previously it only considered the primary screen. With the native, the game handles placing the cursor in the correct screen.

Fixes #109.