### PR TITLE
Fix incorrect item colors in TabInteractiveListItem when item is selected but tab is not focused

### DIFF
--- a/Source/Elements/MenuItems/UIMenuCheckboxItem.cs
+++ b/Source/Elements/MenuItems/UIMenuCheckboxItem.cs
@@ -107,7 +107,7 @@ namespace RAGENativeUI.Elements
             bool isDefaultHightlitedForeColor = HighlightedForeColor == DefaultHighlightedForeColor;
 
             string name;
-            if (Selected && Enabled && isDefaultHightlitedForeColor)
+            if (Selected && CanDrawNavBar && Enabled && isDefaultHightlitedForeColor)
             {
                 name = Checked ? GetChecked(Style, true) : UIMenu.CheckboxBlankSelectedTextureName;
             }
@@ -117,7 +117,7 @@ namespace RAGENativeUI.Elements
             }
 
             Color color = Enabled ?
-                        (Selected && !isDefaultHightlitedForeColor) ? HighlightedForeColor : ForeColor :
+                        (Selected && CanDrawNavBar && !isDefaultHightlitedForeColor) ? HighlightedForeColor : ForeColor :
                         DisabledForeColor;
 
             return (name, color);

--- a/Source/Elements/MenuItems/UIMenuListItem.cs
+++ b/Source/Elements/MenuItems/UIMenuListItem.cs
@@ -230,7 +230,7 @@ namespace RAGENativeUI.Elements
 
             GetBadgeOffsets(out _, out float badgeOffset);
 
-            if (Selected && Enabled)
+            if (Selected && CanDrawNavBar && Enabled)
             {
                 Color textColor = CurrentForeColor;
                 float optTextX = x + width - (0.00390625f * 1.5f) - optTextWidth - (0.0046875f * 1.5f) - badgeOffset;

--- a/Source/Elements/MenuItems/UIMenuScrollerItem.cs
+++ b/Source/Elements/MenuItems/UIMenuScrollerItem.cs
@@ -241,7 +241,7 @@
 
             GetBadgeOffsets(out _, out float badgeOffset);
 
-            if (Selected && (Enabled || ScrollingEnabledWhenDisabled) && ScrollingEnabled)
+            if (Selected && CanDrawNavBar && (Enabled || ScrollingEnabledWhenDisabled) && ScrollingEnabled)
             {
                 Color arrowsColor = CurrentForeColor;
                 if (!Enabled)


### PR DESCRIPTION
Fixes #127.