### PR TITLE
Pause menu mission select tab enhancements

### DIFF
--- a/Source/Elements/Sprite.cs
+++ b/Source/Elements/Sprite.cs
@@ -183,11 +183,11 @@ namespace RAGENativeUI.Elements
         /// <param name="graphics"></param>
         public static void DrawTexture(Texture texture, Point position, Size size, Rage.Graphics graphics)
         {
-            var origRes = Game.Resolution;
-            float aspectRaidou = origRes.Width / (float)origRes.Height;
-            PointF pos = new PointF(position.X / (1080 * aspectRaidou), position.Y / 1080f);
-            SizeF siz = new SizeF(size.Width / (1080 * aspectRaidou), size.Height / 1080f);
-            graphics.DrawTexture(texture, pos.X * Game.Resolution.Width, pos.Y * Game.Resolution.Height, siz.Width * Game.Resolution.Width, siz.Height * Game.Resolution.Height);
+            var origRes = Screen.ActualResolution;
+            float aspectRatio = origRes.Width / (float)origRes.Height;
+            PointF pos = new PointF(position.X / (1080 * aspectRatio), position.Y / 1080f);
+            SizeF siz = new SizeF(size.Width / (1080 * aspectRatio), size.Height / 1080f);
+            graphics.DrawTexture(texture, pos.X * origRes.Width, pos.Y * origRes.Height, siz.Width * origRes.Width, siz.Height * origRes.Height);
         }
 
         /// <summary>

--- a/Source/Examples/PauseMenuExample.cs
+++ b/Source/Examples/PauseMenuExample.cs
@@ -40,7 +40,9 @@
             List<MissionInformation> missionsInfo = new List<MissionInformation>()
             {
                 new MissionInformation("Mission One", new Tuple<string, string>[] { new Tuple<string, string>("This the first info", "Random Info"), new Tuple<string, string>("This the second info", "Random Info #2") }) { Logo = new MissionLogo(Game.CreateTextureFromFile("DefaultSkin.png")) },
-                new MissionInformation("Mission Two", "I have description!", new Tuple<string, string>[] { new Tuple<string, string>("Objective", "Mission Two Objective") }),
+                new MissionInformation("Mission Two", "I have description!", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective") }),
+                new MissionInformation("Mission Three", "This has a description and a full texture", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_chopper", "banner_4") },
+                new MissionInformation("Mission Four", new Tuple<string, string>[] { }) { Logo = new MissionLogo("candc_casinoheist", "stockade_b") },
             };
             tabView.AddTab(missionSelectTab = new TabMissionSelectItem("I'm a Mission Select Tab", missionsInfo));
             missionSelectTab.OnItemSelect += (info) =>

--- a/Source/Examples/PauseMenuExample.cs
+++ b/Source/Examples/PauseMenuExample.cs
@@ -39,11 +39,12 @@
 
             List<MissionInformation> missionsInfo = new List<MissionInformation>()
             {
-                new MissionInformation("Mission One", new Tuple<string, string>[] { new Tuple<string, string>("This the first info", "Random Info"), new Tuple<string, string>("This the second info", "Random Info #2") }) { Logo = new MissionLogo(Game.CreateTextureFromFile("DefaultSkin.png")) },
-                new MissionInformation("Mission Two", "I have description!", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective") }),
+                new MissionInformation("Mission One", "I have description!", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission One Objective") }),
+                new MissionInformation("Mission Two", new Tuple<string, string>[] { new Tuple<string, string>("This the second info", "Random Info"), new Tuple<string, string>("This the second info", "Random Info #2") }) { Logo = new MissionLogo(Game.CreateTextureFromFile("DefaultSkin.png")) },
                 new MissionInformation("Mission Three", "This has a description and a full texture", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_chopper", "banner_4") },
                 new MissionInformation("Mission Four", new Tuple<string, string>[] { }) { Logo = new MissionLogo("candc_casinoheist", "stockade_b") },
                 new MissionInformation("Unreasonably long mission name which really ought to be cut off because it's so stupidly long", "Long description with a~n~very very~n~very very~n~very very~n~very very~n~very very very very very very very very very very long string", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_default", "dump") },
+                new MissionInformation("Mission Item", "Mission with a very tall texture", new Tuple<string, string>[] { Tuple.Create("Info 1", "#1"), Tuple.Create("Info 2", "#2"), Tuple.Create("Info 3", "#3") }) { Logo = new MissionLogo("helicopterhud", "hud_vert") },
             };
             tabView.AddTab(missionSelectTab = new TabMissionSelectItem("Static Mission Select Tab", missionsInfo));
             missionSelectTab.OnItemSelect += (info) =>
@@ -73,6 +74,9 @@
                 tItem.Activated += (s, e) => Game.DisplaySubtitle("Activated Submenu Item #" + submenuTab.Index, 5000);
                 items.Add(tItem);
             }
+
+            items.Add(new TabMissionSelectItem("Submenu Mission Select Item", missionsInfo));
+
             tabView.AddTab(submenuTab = new TabSubmenuItem("A submenu", items));
 
             UIMenuItem[] menuItems = CreateMenuItems();

--- a/Source/Examples/PauseMenuExample.cs
+++ b/Source/Examples/PauseMenuExample.cs
@@ -43,9 +43,9 @@
                 new MissionInformation("Mission Two", "I have description!", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective") }),
                 new MissionInformation("Mission Three", "This has a description and a full texture", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_chopper", "banner_4") },
                 new MissionInformation("Mission Four", new Tuple<string, string>[] { }) { Logo = new MissionLogo("candc_casinoheist", "stockade_b") },
-                new MissionInformation("Mission Five", "Long description with a~n~very very~n~very very~n~very very~n~very very~n~very very very very very very very very very very long string", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_default", "dump") },
+                new MissionInformation("Unreasonably long mission name which really ought to be cut off because it's so stupidly long", "Long description with a~n~very very~n~very very~n~very very~n~very very~n~very very very very very very very very very very long string", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_default", "dump") },
             };
-            tabView.AddTab(missionSelectTab = new TabMissionSelectItem("I'm a Mission Select Tab", missionsInfo));
+            tabView.AddTab(missionSelectTab = new TabMissionSelectItem("Static Mission Select Tab", missionsInfo));
             missionSelectTab.OnItemSelect += (info) =>
             {
                 if (info.Name == "Mission One")
@@ -57,6 +57,8 @@
                     Game.DisplaySubtitle("~b~Mission Two Activated", 5000);
                 }
             };
+
+            tabView.AddTab(new TabMissionSelectItem("Dynamic Mission Select Tab", missionsInfo) { DynamicMissionWidth = true });
 
 
             tabView.AddTab(textTab = new TabTextItem("TabTextItem", "Text Tab Item", "I'm a text tab item"));

--- a/Source/Examples/PauseMenuExample.cs
+++ b/Source/Examples/PauseMenuExample.cs
@@ -43,6 +43,7 @@
                 new MissionInformation("Mission Two", "I have description!", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective") }),
                 new MissionInformation("Mission Three", "This has a description and a full texture", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_chopper", "banner_4") },
                 new MissionInformation("Mission Four", new Tuple<string, string>[] { }) { Logo = new MissionLogo("candc_casinoheist", "stockade_b") },
+                new MissionInformation("Mission Five", "Long description with a~n~very very~n~very very~n~very very~n~very very~n~very very very very very very very very very very long string", new Tuple<string, string>[] { Tuple.Create("Objective", "Mission Two Objective"), Tuple.Create("Some more details", "Mission Two Details") }) { Logo = new MissionLogo("candc_default", "dump") },
             };
             tabView.AddTab(missionSelectTab = new TabMissionSelectItem("I'm a Mission Select Tab", missionsInfo));
             missionSelectTab.OnItemSelect += (info) =>

--- a/Source/Examples/PauseMenuExample.cs
+++ b/Source/Examples/PauseMenuExample.cs
@@ -76,6 +76,7 @@
             }
 
             items.Add(new TabMissionSelectItem("Submenu Mission Select Item", missionsInfo));
+            items.Add(new TabMissionSelectItem("Submenu Dynamic Mission Select Item", missionsInfo) { DynamicMissionWidth = true });
 
             tabView.AddTab(submenuTab = new TabSubmenuItem("A submenu", items));
 

--- a/Source/Examples/PauseMenuExample.cs
+++ b/Source/Examples/PauseMenuExample.cs
@@ -77,6 +77,7 @@
 
             items.Add(new TabMissionSelectItem("Submenu Mission Select Item", missionsInfo));
             items.Add(new TabMissionSelectItem("Submenu Dynamic Mission Select Item", missionsInfo) { DynamicMissionWidth = true });
+            items.Add(new TabMissionSelectItem("Submenu Fixed Ratio Mission Select Item", missionsInfo) { DynamicLogoRatio = false });
 
             tabView.AddTab(submenuTab = new TabSubmenuItem("A submenu", items));
 

--- a/Source/PauseMenu/TabMissionSelectItem.cs
+++ b/Source/PauseMenu/TabMissionSelectItem.cs
@@ -87,6 +87,15 @@ namespace RAGENativeUI.PauseMenu
                 return (float)res.Width / (float)res.Height;
             }
         }
+
+        public bool IsTextureLoaded
+        {
+            get
+            {
+                var res = Resolution;
+                return (res.Width > 0 && res.Height > 0 && !(res.Width == 4 && res.Height == 4));
+            }
+        }
     }
 
     public class TabMissionSelectItem : TabItem
@@ -207,6 +216,7 @@ namespace RAGENativeUI.PauseMenu
 
             var curHeist = Heists[Index];
             var logo = curHeist.Logo;
+            bool logoLoaded = curHeist.Logo?.IsTextureLoaded ?? false;
             float ratio = logo?.Ratio ?? 2f; // width to height ratio of actual texture being rendered this frame
 
             float heistDescHeight = 40 + (40 * curHeist.ValueList.Count);
@@ -248,7 +258,7 @@ namespace RAGENativeUI.PauseMenu
             var missionPoint = new Point(TopLeft.X + activeWidth - logoArea.Width, TopLeft.Y);
 
             // texture/logo rendering
-            if (Heists[Index].Logo == null || (Heists[Index].Logo.Sprite == null && Heists[Index].Logo.Texture == null))
+            if (Heists[Index].Logo == null || !logoLoaded || (Heists[Index].Logo.Sprite == null && Heists[Index].Logo.Texture == null))
             {
                 drawTexture = false;
                 _noLogo.Size = logoSize;

--- a/Source/PauseMenu/TabMissionSelectItem.cs
+++ b/Source/PauseMenu/TabMissionSelectItem.cs
@@ -112,9 +112,11 @@ namespace RAGENativeUI.PauseMenu
         public List<MissionInformation> Heists { get; set; }
         public int Index { get; set; }
 
-        public bool DynamicMissionWidth { get; set; } = true;
+        public bool DynamicMissionWidth { get; set; } = false;
         public int MinMissionWidth { get; set; } = 512;
+        public int MaxMissionWidth { get; set; } = 1440;
         public int MinLabelWidth { get; set; } = 100;
+        public int MaxLabelWidth { get; set; } = 512;
 
         protected const int MaxItemsPerView = 15;
         protected int _minItem;
@@ -189,40 +191,20 @@ namespace RAGENativeUI.PauseMenu
             res = UIMenu.GetScreenResolutionMantainRatio();
             var activeWidth = res.Width - SafeSize.X * 2;
             var activeHeight = res.Height - SafeSize.Y * 2;
-            logoSize = new Size(baseLogoWidth, (int)(0.5f * baseLogoWidth));
 
             if (DynamicMissionWidth)
             {
                 // ensure logo height does not exceed safe zone, logo width is over min but optimized to text width
 
                 float maxLabelWidth = 30;
-                // float maxItemDescHeight = 40;
 
                 foreach (var heist in Heists)
                 {
                     maxLabelWidth = Math.Max(maxLabelWidth, ResText.MeasureStringWidth(heist.Name, Common.EFont.ChaletLondon, 0.35f));
                 }
 
-                maxLabelWidth = Math.Max(MinLabelWidth, maxLabelWidth + 20);
-                baseLogoWidth = (int)Math.Max(activeWidth - maxLabelWidth, MinMissionWidth);
-
-                /*
-                foreach (var heist in Heists)
-                {
-                    float heistDescHeight = 40 + (40 * heist.ValueList.Count);
-                    if (!string.IsNullOrWhiteSpace(heist.Description))
-                    {
-                        // heistDescHeight += TextCommands.GetLineCount(heist.Description, 0.0f, 0.0f) * 45 + 4;
-                        int lineCount = TextCommands.GetLineCount(heist.Description, new TextStyle(TextFont.ChaletLondon, Color.White, 0.35f, TextJustification.Left, 0, logoWidth / 1920f), 0f, 0f);
-                        heistDescHeight += (lineCount * 25) + 20;
-                    }
-                    maxItemDescHeight = Math.Max(maxItemDescHeight, heistDescHeight);
-                }
-                */
-
-                // var logoHeight = activeHeight - maxItemDescHeight;
-                // logoSize = new Size((int)logoWidth, (int)logoHeight);
-                // baseLogoWidth = (int)logoWidth;
+                maxLabelWidth = Math.Min(MaxLabelWidth, Math.Max(MinLabelWidth, maxLabelWidth + 20));
+                baseLogoWidth = (int)Math.Min(MaxMissionWidth, Math.Max(activeWidth - maxLabelWidth, MinMissionWidth));
             }
 
             var curHeist = Heists[Index];
@@ -236,9 +218,8 @@ namespace RAGENativeUI.PauseMenu
                 heistDescHeight += (lineCount * 25) + 20;
             }
 
-            float logoWidth = baseLogoWidth;
             float logoHeight = Math.Min(baseLogoWidth / ratio, activeHeight - heistDescHeight);
-            logoWidth = logoHeight * ratio;
+            float logoWidth = logoHeight * ratio;
             logoSize = new Size((int)logoWidth, (int)logoHeight);
             logoArea = new Size(baseLogoWidth, (int)logoHeight);
 
@@ -251,8 +232,14 @@ namespace RAGENativeUI.PauseMenu
             var counter = 0;
             for (int i = _minItem; i < Math.Min(Heists.Count, _maxItem); i++)
             {
+                string listItemName = Heists[i].Name;
+                var nameLength = ResText.MeasureStringWidth(listItemName, Common.EFont.ChaletLondon, 0.35f);
+                if(nameLength > itemSize.Width - 10)
+                {
+                    listItemName = listItemName.Substring(0, Math.Max(Math.Min(listItemName.Length, 10), (int)((itemSize.Width - 20) / nameLength * listItemName.Length))).Trim() + "...";
+                }
                 ResRectangle.Draw(SafeSize.AddPoints(new Point(0, (itemSize.Height + 3) * counter)), itemSize, (Index == i && Focused) ? Color.FromArgb(fullAlpha, Color.White) : Color.FromArgb(blackAlpha, Color.Black));
-                ResText.Draw(Heists[i].Name, SafeSize.AddPoints(new Point(6, 5 + (itemSize.Height + 3) * counter)), 0.35f, Color.FromArgb(fullAlpha, (Index == i && Focused) ? Color.Black : Color.White), Common.EFont.ChaletLondon, false);
+                ResText.Draw(listItemName, SafeSize.AddPoints(new Point(6, 5 + (itemSize.Height + 3) * counter)), 0.35f, Color.FromArgb(fullAlpha, (Index == i && Focused) ? Color.Black : Color.White), Common.EFont.ChaletLondon, false);
                 counter++;
             }
 

--- a/Source/PauseMenu/TabMissionSelectItem.cs
+++ b/Source/PauseMenu/TabMissionSelectItem.cs
@@ -254,7 +254,8 @@ namespace RAGENativeUI.PauseMenu
                 counter++;
             }
 
-            int logoPadding = (int)(0.5f * (logoArea.Width - logoSize.Width));
+            var logoPaddingLeft = (int)Math.Floor(0.5f * (logoArea.Width - logoSize.Width));
+            var logoPaddingRight = (int)Math.Ceiling(0.5f * (logoArea.Width - logoSize.Width));
             var missionPoint = new Point(TopLeft.X + activeWidth - logoArea.Width, TopLeft.Y);
 
             // texture/logo rendering
@@ -262,7 +263,7 @@ namespace RAGENativeUI.PauseMenu
             {
                 drawTexture = false;
                 _noLogo.Size = logoSize;
-                _noLogo.Position = missionPoint.AddPoints(new Point(logoPadding, 0));
+                _noLogo.Position = missionPoint.AddPoints(new Point(logoPaddingLeft, 0));
                 _noLogo.Color = Color.FromArgb(blackAlpha, 0, 0, 0);
                 _noLogo.Draw();
             }
@@ -274,7 +275,7 @@ namespace RAGENativeUI.PauseMenu
             {
                 drawTexture = false;
                 Sprite sprite = Heists[Index].Logo.Sprite;
-                sprite.Position = missionPoint.AddPoints(new Point(logoPadding, 0));
+                sprite.Position = missionPoint.AddPoints(new Point(logoPaddingLeft, 0));
                 sprite.Size = logoSize;
                 sprite.Color = Color.FromArgb(blackAlpha, 255, 255, 255);
                 sprite.Draw();
@@ -285,8 +286,8 @@ namespace RAGENativeUI.PauseMenu
             }
             
             // padding around texture background
-            ResRectangle.Draw(missionPoint, new Size(logoPadding, logoArea.Height), Color.FromArgb(blackAlpha, Color.Black));
-            ResRectangle.Draw(missionPoint.AddPoints(new Point(logoArea.Width - logoPadding, 0)), new Size(logoPadding, logoArea.Height), Color.FromArgb(blackAlpha, Color.Black));
+            ResRectangle.Draw(missionPoint, new Size(logoPaddingLeft, logoArea.Height), Color.FromArgb(blackAlpha, Color.Black));
+            ResRectangle.Draw(missionPoint.AddPoints(new Point(logoArea.Width - logoPaddingRight, 0)), new Size(logoPaddingRight, logoArea.Height), Color.FromArgb(blackAlpha, Color.Black));
 
             // description text and background rendering
             ResRectangle.Draw(missionPoint.AddPoints(new Point(0, logoArea.Height)), new Size(logoArea.Width, 40), Color.FromArgb(fullAlpha, Color.Black));

--- a/Source/PauseMenu/TabMissionSelectItem.cs
+++ b/Source/PauseMenu/TabMissionSelectItem.cs
@@ -122,6 +122,7 @@ namespace RAGENativeUI.PauseMenu
         public bool DynamicMissionWidth { get; set; } = false;
         public int MinMissionWidth { get; set; } = 512;
         public int MaxMissionWidth { get; set; } = 1440;
+        public int MaxLogoHeight { get; set; } = 512;
         public int MinLabelWidth { get; set; } = 100;
         public int MaxLabelWidth { get; set; } = 512;
 
@@ -217,8 +218,7 @@ namespace RAGENativeUI.PauseMenu
             var curHeist = Heists[Index];
             var logo = curHeist.Logo;
             bool logoLoaded = curHeist.Logo?.IsTextureLoaded ?? false;
-            float ratio = logo?.Ratio ?? 2f; // width to height ratio of actual texture being rendered this frame
-
+            
             float heistDescHeight = 40 + (40 * curHeist.ValueList.Count);
             if (!string.IsNullOrWhiteSpace(curHeist.Description))
             {
@@ -228,8 +228,9 @@ namespace RAGENativeUI.PauseMenu
                 ResText.Draw("", Point.Empty, 0.01f, Color.FromArgb(0, 0, 0, 0), Common.EFont.ChaletLondon, false);
             }
 
-            float logoHeight = Math.Min(baseLogoWidth / ratio, activeHeight - heistDescHeight);
-            float logoWidth = logoHeight * ratio;
+            float logoRatio = logo?.Ratio ?? 2f; // width to height ratio of actual texture being rendered this frame
+            float logoHeight = Math.Min(Math.Min(baseLogoWidth / logoRatio, activeHeight - heistDescHeight), MaxLogoHeight);
+            float logoWidth = logoHeight * logoRatio;
             logoSize = new Size((int)logoWidth, (int)logoHeight);
             logoArea = new Size(baseLogoWidth, (int)logoHeight);
 


### PR DESCRIPTION
Several improvements to `TabMissionSelectItem`:

 - Added optional dynamic scaling of mission info area based on screen size and text length in item labels
 - Added dynamic resizing of mission logo texture to support various aspect ratios
 - Refactored `Draw()` function to render correctly as a submenu item
 - Updated examples to demonstrate these new capabilities