### PR TITLE
Added controls logic for IsJustPressedRepeated to tab items

### DIFF
--- a/Source/PauseMenu/TabItem.cs
+++ b/Source/PauseMenu/TabItem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Drawing;
+using Rage;
 using RAGENativeUI.Elements;
 
 namespace RAGENativeUI.PauseMenu
@@ -13,7 +14,22 @@ namespace RAGENativeUI.PauseMenu
             Title = name;
             DrawBg = true;
             UseDynamicPositionment = true;
+
+            SetKey(Common.MenuControls.Up, GameControl.MoveUpOnly, 2);
+            SetKey(Common.MenuControls.Up, GameControl.FrontendUp, 2);
+            SetKey(Common.MenuControls.Up, GameControl.CursorScrollUp, 2);
+            SetKey(Common.MenuControls.Down, GameControl.MoveDownOnly, 2);
+            SetKey(Common.MenuControls.Down, GameControl.FrontendDown, 2);
+            SetKey(Common.MenuControls.Down, GameControl.CursorScrollDown, 2);
+            SetKey(Common.MenuControls.Left, GameControl.FrontendLeft, 2);
+            SetKey(Common.MenuControls.Right, GameControl.FrontendRight, 2);
+            SetKey(Common.MenuControls.Select, GameControl.FrontendAccept, 2);
+            SetKey(Common.MenuControls.Back, GameControl.FrontendCancel, 2);
+            SetKey(Common.MenuControls.Back, GameControl.FrontendPause, 2);
+            SetKey(Common.MenuControls.Back, GameControl.CursorCancel, 2);
         }
+
+        protected void SetKey(Common.MenuControls control, GameControl gtaControl, int controlIndex) => controls[control].NativeControls.Add((controlIndex, gtaControl));
 
         public bool Visible { get; set; }
         public bool Focused { get; set; }
@@ -45,8 +61,17 @@ namespace RAGENativeUI.PauseMenu
             Activated?.Invoke(this, EventArgs.Empty);
         }
 
+        internal UIMenu.Controls controls = new UIMenu.Controls();
+
         public virtual void ProcessControls()
         {
+            if (JustOpened)
+            {
+                JustOpened = false;
+                return;
+            }
+
+            controls.Update();
         }
 
         public virtual void Draw()

--- a/Source/PauseMenu/TabMissionSelectItem.cs
+++ b/Source/PauseMenu/TabMissionSelectItem.cs
@@ -199,20 +199,22 @@ namespace RAGENativeUI.PauseMenu
             if (Index < 0 || Index >= Heists.Count)
                 missions.RefreshIndex();
 
-            if (Common.IsDisabledControlJustPressed(0, GameControl.CellphoneSelect))
+            base.ProcessControls();
+
+            if (controls[Common.MenuControls.Select].IsJustPressed)
             {
                 TabView.PlaySelectSound();
                 OnItemSelect?.Invoke(Heists[Index]);
             }
 
-            if (Common.IsDisabledControlJustPressed(0, GameControl.FrontendUp) || Common.IsDisabledControlJustPressed(0, GameControl.MoveUpOnly))
+            else if (controls[Common.MenuControls.Up].IsJustPressedRepeated)
             {
                 missions.MoveToPreviousItem();
                 TabView.PlayNavUpDownSound();
                 OnIndexChanged?.Invoke(this, Index, Heists[Index]);
             }
 
-            else if (Common.IsDisabledControlJustPressed(0, GameControl.FrontendDown) || Common.IsDisabledControlJustPressed(0, GameControl.MoveDownOnly))
+            else if (controls[Common.MenuControls.Down].IsJustPressedRepeated)
             {
                 missions.MoveToNextItem();
                 TabView.PlayNavUpDownSound();

--- a/Source/PauseMenu/TabSubmenuItem.cs
+++ b/Source/PauseMenu/TabSubmenuItem.cs
@@ -84,9 +84,11 @@ namespace RAGENativeUI.PauseMenu
             if (!Focused || Items.Count == 0 || Index < 0 || Index >= Items.Count)
                 return;
 
+            base.ProcessControls();
+
             if (Items[Index].Focused)
             {
-                if (Common.IsDisabledControlJustPressed(0, GameControl.CellphoneCancel) && Focused && Parent.FocusLevel > 1)
+                if (Focused && Parent.FocusLevel > 1 && controls[Common.MenuControls.Back].IsJustPressed)
                 {
                     TabView.PlayCancelSound();
                     if (Items[Index].CanBeFocused && Items[Index].Focused)
@@ -100,7 +102,7 @@ namespace RAGENativeUI.PauseMenu
             }
             else
             {
-                if (Common.IsDisabledControlJustPressed(0, GameControl.CellphoneSelect) && Focused && Parent.FocusLevel == 1)
+                if (Focused && Parent.FocusLevel == 1 && controls[Common.MenuControls.Select].IsJustPressed)
                 {
                     TabView.PlaySelectSound();
                     OnItemSelect?.Invoke(Items[Index]);
@@ -117,14 +119,14 @@ namespace RAGENativeUI.PauseMenu
                     }
                 }
 
-                if (Common.IsDisabledControlJustPressed(0, GameControl.FrontendUp) || Common.IsDisabledControlJustPressed(0, GameControl.MoveUpOnly) || Common.IsDisabledControlJustPressed(0, GameControl.CursorScrollUp) && Parent.FocusLevel == 1)
+                if (Parent.FocusLevel == 1 && controls[Common.MenuControls.Up].IsJustPressedRepeated)
                 {
                     tabList.MoveToPreviousItem();
                     TabView.PlayNavUpDownSound();
                     OnIndexChanged?.Invoke(this, tabList.CurrentSelection, tabList.CurrentItem);
                 }
 
-                else if (Common.IsDisabledControlJustPressed(0, GameControl.FrontendDown) || Common.IsDisabledControlJustPressed(0, GameControl.MoveDownOnly) || Common.IsDisabledControlJustPressed(0, GameControl.CursorScrollDown) && Parent.FocusLevel == 1)
+                else if (Parent.FocusLevel == 1 && controls[Common.MenuControls.Down].IsJustPressedRepeated)
                 {
                     tabList.MoveToNextItem();
                     TabView.PlayNavUpDownSound();

--- a/Source/ScrollableListBase.cs
+++ b/Source/ScrollableListBase.cs
@@ -144,9 +144,6 @@ namespace RAGENativeUI
 
         public IEnumerable<(int iterIndex, int itemIndex, T item, bool isItemSelected)> IterateVisibleItems()
         {
-            // if selection is -1 (none) or out of range, do not return anything
-            if (CurrentSelection < 0 || CurrentSelection >= Items.Count) yield break;
-
             for (int c = minItem; c <= maxItem; c++)
             {
                 yield return (c - minItem, c, Items[c], c == CurrentSelection);


### PR DESCRIPTION
Added a `UIMenu.Controls` instance to base `TabItem` class, and implemented in `TabMissionSelectItem` and `TabSubmenuItem` to support scrolling through multiple sub-items with acceleration from a single press.